### PR TITLE
Correct info on mixed-precision field collection iterators.

### DIFF
--- a/documentation/source/user_guide/lfric_datamodel/field.rst
+++ b/documentation/source/user_guide/lfric_datamodel/field.rst
@@ -262,9 +262,7 @@ in the following code can be either 32-bit or 64-bit:
 
    Field collections support the ability to access an individual named
    field and also the ability to iterate over all the fields in the
-   field collection. Support of iterators, however, is only available
-   for fields with the default precision as defined in the
-   ``field_mod`` module.
+   field collection.
 
 Integer fields
 ==============


### PR DESCRIPTION
Field collection iterators had a helper function to enable the user to iterate over real fields. This didn't work when fields were mixed precision. I have removed the helper function so the user now has to use the underlying iterator - which does support mixed precision. The docs need updating so the comment that describes the helper function not working for mixed precision needs to be removed.