### PR TITLE
Some small fixes to the issue templates forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Contact Details
       description: How can we get in touch with you if we need more info?
-      placeholder: ex. email@example.com
+      placeholder: e.g. email@example.com
     validations:
       required: false
   - type: textarea
@@ -20,7 +20,8 @@ body:
     attributes:
       label: Are there any linked Issues or Pull Requests?
       description: Please tell us about any issues that might be associated with this bug or PRs that may be affected.
-      placeholder: e.g. "#12, MetOffice/Vernier#33"
+      placeholder: e.g. "#12, MetOffice/Vernier#33, lfric-srs#1981,
+      lfric_apps-srs#123"
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/custom_issue.yml
+++ b/.github/ISSUE_TEMPLATE/custom_issue.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Contact Details
       description: How can we get in touch with you if we need more info?
-      placeholder: ex. email@example.com
+      placeholder: e.g. email@example.com
     validations:
       required: false
   - type: textarea
@@ -20,7 +20,8 @@ body:
     attributes:
       label: Are there any linked Issues or Pull Requests?
       description: Please tell us about any issues that might be associated with this bug or PRs that may be affected.
-      placeholder: e.g. "#12, MetOffice/Vernier#33"
+      placeholder: e.g. "#12, MetOffice/Vernier#33, lfric-srs#1981,
+      lfric_apps-srs#123"
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -20,7 +20,8 @@ body:
     attributes:
       label: Are there any linked Issues or Pull Requests?
       description: Please tell us about any issues that might be associated with this bug or PRs that may be affected.
-      placeholder: e.g. "#12, MetOffice/Vernier#33"
+      placeholder: e.g. "#12, MetOffice/Vernier#33, lfric-srs#1981,
+      lfric_apps-srs#123"
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
I've removed the shell rendering from the issue templates for custom and documentation issues as it doesn't really feel right to default to that form for those types of issues. Whilst doing so I also fixed an issue with inconsistent e.g./ex. for the placeholder text and added examples for linking to SRS tickets.