### PR TITLE
Bump "artifact" action to v4.

### DIFF
--- a/.github/workflows/sphinx-preview.yml
+++ b/.github/workflows/sphinx-preview.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         chmod -c -R +rX "documentation/build/html/"
     - id: deployment
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         name: github-pages
         path: documentation/build/html

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         chmod -c -R +rX "documentation/build/html/"
     - id: deployment
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         name: github-pages
         path: documentation/build/html


### PR DESCRIPTION
Version 3 is to be deprecated on the 5th of December 2024.