### PR TITLE
Update the dist mem docs to explain the alternative to inner halos

### DIFF
--- a/documentation/source/user_guide/technical_articles/lfric_distmem_impl.rst
+++ b/documentation/source/user_guide/technical_articles/lfric_distmem_impl.rst
@@ -189,7 +189,7 @@ to support a chosen iteration strategy.
 
 By default, the cells in the partition are ordered using the mesh-ids
 from the global mesh. This makes cells that are geographically
-close to each to be close to each other in the list. This can aid with
+nearby close to each other in the list. This can aid with
 performance, through better cache use.
 
 Alternatively, the cells can be ordered so that they support the


### PR DESCRIPTION
The docs already explained the method for generating inner halos, so this change was just to expain the alternative that is now supported.