### PR TITLE
Add reference to ``log_at_level`` API

### DIFF
--- a/documentation/source/how_to_use_it/components/driver.rst
+++ b/documentation/source/how_to_use_it/components/driver.rst
@@ -49,9 +49,8 @@ system.
 
 Once initialised :ref:`logging` may proceed as normal.
 
-When you have logged the last thing you care to log call ``final_logger``. The
-string passed to it is used only to output a final message. This rather
-unnecessary feature may well be removed in the future.
+When you have logged the last thing you care to log call ``final_logger``. This
+takes a string which should be the same as the name passed to ``init_logger``.
 
 .. _driver configuration:
 

--- a/documentation/source/how_to_use_it/technical_articles/logging.rst
+++ b/documentation/source/how_to_use_it/technical_articles/logging.rst
@@ -134,10 +134,8 @@ necessary.
      call log_event(log_scratch_space, log_level_debug)
    end if
 
-Note that there is duplication of ``log_level_debug`` here, if they are not
-the same unexpected behaviour will ensue. This is not currently considered an
-issue given that any solution so far determine to remove the duplication is
-complicated and probably worse than the problem.
+Note that there is duplication of ``log_level_debug`` here. This is the normal
+pattern of use - dissimilar log levels may not give the behaviour you expect.
 
 Get the Log Level
 -----------------


### PR DESCRIPTION
# Description

In order to support a common usage pattern around only calculating debug values if they are actually going to be logged, an addition has been made to the logging API. This change documents that.

Closes #134 

## Linked issues

The API change is implemented in ticket 4682 of the core repository.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] New tests have been added.
- [ ] Tests have been modified to accommodate this change.
- [ ] GitHub workflows have been changed or added.

# Checklist:

- [ ] The change has been checked for design compliance by an experienced SSE 
      <!-- All none trivial tickets should be seen by an appropriately experienced 
           SSE as part of a design review or as part of the normal review process -->
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes, for both debug and optimised builds.
- [x] No AI tools have been used in the creation of this change.

## Reasoning on why any of the above boxes have not been checked

This is a documentation only change.

# Review Checks (To be filled in by the reviewer/s)

- [ ] Has the developer completed the appropriate sections above?
- [ ] Is the change compliant with LFRic Core principles?
- [ ] Is the testing coverage sufficient?
- [ ] Have any technical debt workarounds identified had issues opened and interested parties notified?
