### PR TITLE
Fix climate runs performance issue. 

### DIFF
--- a/components/lfric-xios/source/lfric_xios_file_mod.f90
+++ b/components/lfric-xios/source/lfric_xios_file_mod.f90
@@ -390,8 +390,6 @@ subroutine register_with_context(self)
   if (.not. self%freq_ts == undef_freq) then
     self%frequency = self%freq_ts * timestep_duration
     call xios_set_attr( self%handle, output_freq=self%frequency )
-  else
-    call xios_set_attr( self%handle, output_freq=timestep_duration )
   end if
 
   ! Set the date of the first operation


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @allynt 
Code Reviewer: @james-bruten-mo 

<!-- To be completed by the developer -->

[#4576](https://code.metoffice.gov.uk/trac/lfric/ticket/4576) introduced some calls to XIOS that are making climate runs about 10x slower than they were. Here I'm removing the call to xios_set_attr that happens on every timestep which is a fix suggested by Ian Boutle. 

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's
      [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid undertanding and enhance the
      readability of the code
- [x] My changes generate no new warnings

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (eg. API changes) I have also run the LFRic Apps test suite
      using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource
      and have been allocated to an appropriate testing group (i.e. the
      developer tests are for jobs which use a small amount of compute resource
      and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_core - core_fix/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | core_fix/run1 |
| Suite User | jennifer.hickson |
| Workflow Start | 2025-12-05T09:26:52 |
| Groups Run | suite_default |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [jennyhickson/lfric_core@read_fix](https://github.com/jennyhickson/lfric_core/tree/read_fix) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@main](https://github.com/MetOffice/SimSys_Scripts/tree/main) | True |

## Task Information
<details>
<summary>:white_check_mark: succeeded tasks - 372</summary>

| Task | State |
| :--- | :--- |
| build_coupled_azspice_gnu_fast-debug-64bit | succeeded |
| build_coupled_azspice_gnu_full-debug-64bit | succeeded |
| build_coupled_ex1a_cce_fast-debug-64bit | succeeded |
| build_coupled_ex1a_cce_full-debug-64bit | succeeded |
| build_coupling_unit_tests_azspice_gnu_32bit | succeeded |
| build_coupling_unit_tests_azspice_gnu_64bit | succeeded |
| build_coupling_unit_tests_ex1a_gnu_32bit | succeeded |
| build_coupling_unit_tests_ex1a_gnu_64bit | succeeded |
| build_driver_unit_tests_azspice_gnu_32bit | succeeded |
| build_driver_unit_tests_azspice_gnu_64bit | succeeded |
| build_driver_unit_tests_ex1a_gnu_32bit | succeeded |
| build_driver_unit_tests_ex1a_gnu_64bit | succeeded |
| build_infrastructure_integration_tests_azspice_gnu_32bit | succeeded |
| build_infrastructure_integration_tests_azspice_gnu_64bit | succeeded |
| build_infrastructure_integration_tests_ex1a_cce_32bit | succeeded |
| build_infrastructure_integration_tests_ex1a_cce_64bit | succeeded |
| build_infrastructure_unit_tests_azspice_gnu_32bit | succeeded |
| build_infrastructure_unit_tests_azspice_gnu_64bit | succeeded |
| build_infrastructure_unit_tests_ex1a_gnu_32bit | succeeded |
| build_infrastructure_unit_tests_ex1a_gnu_64bit | succeeded |
| build_io_demo_azspice_gnu_fast-debug-32bit | succeeded |
| build_io_demo_azspice_gnu_fast-debug-64bit | succeeded |
| build_io_demo_azspice_gnu_full-debug-64bit | succeeded |
| build_io_demo_ex1a_cce_fast-debug-32bit | succeeded |
| build_io_demo_ex1a_cce_fast-debug-64bit | succeeded |
| build_io_demo_ex1a_cce_full-debug-64bit | succeeded |
| build_io_demo_ex1a_gnu_fast-debug-32bit | succeeded |
| build_io_demo_ex1a_gnu_fast-debug-64bit | succeeded |
| build_io_demo_unit_tests_azspice_gnu_64bit | succeeded |
| build_io_demo_unit_tests_ex1a_gnu_64bit | succeeded |
| build_lbc_demo_azspice_gnu_fast-debug-64bit | succeeded |
| build_lbc_demo_azspice_gnu_full-debug-64bit | succeeded |
| build_lbc_demo_ex1a_cce_fast-debug-64bit | succeeded |
| build_lbc_demo_ex1a_gnu_fast-debug-64bit | succeeded |
| build_lfric_xios_integration_tests_azspice_gnu_64bit | succeeded |
| build_lfric_xios_integration_tests_ex1a_cce_64bit | succeeded |
| build_lfric_xios_unit_tests_azspice_gnu_64bit | succeeded |
| build_lfric_xios_unit_tests_ex1a_gnu_64bit | succeeded |
| build_mesh_azspice_gnu_fast-debug-64bit | succeeded |
| build_mesh_ex1a_gnu_fast-debug-64bit | succeeded |
| build_mesh_tools_azspice_gnu_fast-debug-64bit | succeeded |
| build_mesh_tools_azspice_gnu_full-debug-64bit | succeeded |
| build_mesh_tools_ex1a_cce_fast-debug-64bit | succeeded |
| build_mesh_tools_ex1a_cce_full-debug-64bit | succeeded |
| build_mesh_tools_ex1a_gnu_fast-debug-64bit | succeeded |
| build_mesh_tools_unit_tests_azspice_gnu_64bit | succeeded |
| build_mesh_tools_unit_tests_ex1a_gnu_64bit | succeeded |
| build_science_unit_tests_azspice_gnu_32bit | succeeded |
| build_science_unit_tests_azspice_gnu_64bit | succeeded |
| build_science_unit_tests_ex1a_gnu_32bit | succeeded |
| build_science_unit_tests_ex1a_gnu_64bit | succeeded |
| build_simple_diffusion_azspice_gnu_fast-debug-64bit | succeeded |
| build_simple_diffusion_azspice_gnu_full-debug-64bit | succeeded |
| build_simple_diffusion_ex1a_cce_fast-debug-64bit | succeeded |
| build_simple_diffusion_ex1a_cce_full-debug-64bit | succeeded |
| build_simple_diffusion_ex1a_gnu_full-debug-64bit | succeeded |
| build_simple_diffusion_unit_tests_azspice_gnu_64bit | succeeded |
| build_simple_diffusion_unit_tests_ex1a_gnu_64bit | succeeded |
| build_skeleton_azspice_gnu_fast-debug-64bit | succeeded |
| build_skeleton_azspice_gnu_full-debug-64bit | succeeded |
| build_skeleton_ex1a_cce_full-debug-64bit | succeeded |
| build_skeleton_ex1a_gnu_fast-debug-64bit | succeeded |
| build_skeleton_ex1a_gnu_full-debug-64bit | succeeded |
| build_skeleton_unit_tests_azspice_gnu_64bit | succeeded |
| build_skeleton_unit_tests_ex1a_gnu_64bit | succeeded |
| check_coupled_default-C12_azspice_gnu_fast-debug-64bit | succeeded |
| check_coupled_default-C12_azspice_gnu_full-debug-64bit | succeeded |
| check_coupled_default-C12_ex1a_cce_fast-debug-64bit | succeeded |
| check_coupled_default-C12_ex1a_cce_full-debug-64bit | succeeded |
| check_io_demo_default-C24_azspice_gnu_fast-debug-32bit | succeeded |
| check_io_demo_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| check_io_demo_default-C24_ex1a_cce_fast-debug-32bit | succeeded |
| check_io_demo_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| check_io_demo_multifile-C24_azspice_gnu_fast-debug-32bit | succeeded |
| check_io_demo_multifile-C24_azspice_gnu_fast-debug-64bit | succeeded |
| check_io_demo_multifile-C24_ex1a_cce_fast-debug-32bit | succeeded |
| check_io_demo_multifile-C24_ex1a_cce_fast-debug-64bit | succeeded |
| check_io_demo_multifile-C24_ex1a_gnu_fast-debug-32bit | succeeded |
| check_io_demo_multifile-C24_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c1_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c1_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c1_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c2_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c2_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c2_ex1a_cce_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c3_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c3_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c3_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-maps_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-maps_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-maps_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op-nonuniform_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-rotated_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-rotated_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-rotated_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_equator-band_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_equator-band_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_equator-band_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_equator_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_equator_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_equator_ex1a_cce_full-debug-64bit | succeeded |
| check_mesh_tools_falklands_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_falklands_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_falklands_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_lam_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_lam_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_lam_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_london-model_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_london-model_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_london-model_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_nzlam4_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_nzlam4_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_nzlam4_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-bi-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-bi-periodic_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-bi-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-maps_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-maps_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-maps_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-non-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-non-periodic_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-non-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-op-lam_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-op-lam_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-op-lam_ex1a_cce_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-centres_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-centres_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-centres_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-nodes_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-nodes_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-nodes_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-points_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-points_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-points_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-x_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-x_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-x_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-y_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-y_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-y_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_polar_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_polar_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_polar_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_uk_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_uk_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_uk_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_var-seuk_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_var-seuk_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_var-seuk_ex1a_gnu_fast-debug-64bit | succeeded |
| check_simple_diffusion_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| check_simple_diffusion_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| check_simple_diffusion_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| check_skeleton_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| check_skeleton_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| check_skeleton_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| config_dump_checker | succeeded |
| export-source | succeeded |
| export-source_azspice | succeeded |
| export-source_ex1a | succeeded |
| global_variables_checker | succeeded |
| housekeep_azspice | succeeded |
| housekeep_ex1a | succeeded |
| python_unit_tests | succeeded |
| remote-init_azspice | succeeded |
| remote-init_ex1a | succeeded |
| rose-stem_lint_checker | succeeded |
| run_coupled_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_coupled_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_coupled_default-C12_azspice_gnu_fast-debug-64bit | succeeded |
| run_coupled_default-C12_azspice_gnu_full-debug-64bit | succeeded |
| run_coupled_default-C12_ex1a_cce_fast-debug-64bit | succeeded |
| run_coupled_default-C12_ex1a_cce_full-debug-64bit | succeeded |
| run_coupling_unit_tests_azspice_gnu_32bit | succeeded |
| run_coupling_unit_tests_azspice_gnu_64bit | succeeded |
| run_coupling_unit_tests_ex1a_gnu_32bit | succeeded |
| run_coupling_unit_tests_ex1a_gnu_64bit | succeeded |
| run_driver_unit_tests_azspice_gnu_32bit | succeeded |
| run_driver_unit_tests_azspice_gnu_64bit | succeeded |
| run_driver_unit_tests_ex1a_gnu_32bit | succeeded |
| run_driver_unit_tests_ex1a_gnu_64bit | succeeded |
| run_infrastructure_integration_tests_azspice_gnu_32bit | succeeded |
| run_infrastructure_integration_tests_azspice_gnu_64bit | succeeded |
| run_infrastructure_integration_tests_ex1a_cce_32bit | succeeded |
| run_infrastructure_integration_tests_ex1a_cce_64bit | succeeded |
| run_infrastructure_unit_tests_azspice_gnu_32bit | succeeded |
| run_infrastructure_unit_tests_azspice_gnu_64bit | succeeded |
| run_infrastructure_unit_tests_ex1a_gnu_32bit | succeeded |
| run_infrastructure_unit_tests_ex1a_gnu_64bit | succeeded |
| run_io_demo_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_io_demo_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_io_demo_default-C24_azspice_gnu_fast-debug-32bit | succeeded |
| run_io_demo_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| run_io_demo_default-C24_ex1a_cce_fast-debug-32bit | succeeded |
| run_io_demo_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| run_io_demo_multifile-C24_azspice_gnu_fast-debug-32bit | succeeded |
| run_io_demo_multifile-C24_azspice_gnu_fast-debug-64bit | succeeded |
| run_io_demo_multifile-C24_ex1a_cce_fast-debug-32bit | succeeded |
| run_io_demo_multifile-C24_ex1a_cce_fast-debug-64bit | succeeded |
| run_io_demo_multifile-C24_ex1a_gnu_fast-debug-32bit | succeeded |
| run_io_demo_multifile-C24_ex1a_gnu_fast-debug-64bit | succeeded |
| run_io_demo_unit_tests_azspice_gnu_64bit | succeeded |
| run_io_demo_unit_tests_ex1a_gnu_64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lfric_xios_integration_tests_azspice_gnu_64bit | succeeded |
| run_lfric_xios_integration_tests_ex1a_cce_64bit | succeeded |
| run_lfric_xios_unit_tests_azspice_gnu_64bit | succeeded |
| run_lfric_xios_unit_tests_ex1a_gnu_64bit | succeeded |
| run_mesh_C12_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_C12_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_C24_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_C24_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_LAM50x50-2x2_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_LAM50x50-2x2_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_1x1P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_2x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_8x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_canned_cubedsphere_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_canned_planar_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c1_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c1_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c1_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c2_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c2_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c2_ex1a_cce_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c3_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c3_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c3_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-maps_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-maps_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-maps_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op-nonuniform_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-rotated_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-rotated_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-rotated_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_equator-band_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_equator-band_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_equator-band_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_equator_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_equator_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_equator_ex1a_cce_full-debug-64bit | succeeded |
| run_mesh_tools_falklands_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_falklands_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_falklands_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_lam_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_lam_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_lam_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_london-model_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_london-model_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_london-model_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_nzlam4_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_nzlam4_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_nzlam4_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-bi-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-bi-periodic_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-bi-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-maps_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-maps_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-maps_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-non-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-non-periodic_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-non-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-op-lam_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-op-lam_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-op-lam_ex1a_cce_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-centres_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-centres_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-centres_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-nodes_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-nodes_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-nodes_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-points_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-points_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-points_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-x_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-x_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-x_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-y_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-y_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-y_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_polar_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_polar_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_polar_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_uk_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_uk_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_uk_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_unit_tests_azspice_gnu_64bit | succeeded |
| run_mesh_tools_unit_tests_ex1a_gnu_64bit | succeeded |
| run_mesh_tools_var-seuk_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_var-seuk_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_var-seuk_ex1a_gnu_fast-debug-64bit | succeeded |
| run_science_unit_tests_azspice_gnu_32bit | succeeded |
| run_science_unit_tests_azspice_gnu_64bit | succeeded |
| run_science_unit_tests_ex1a_gnu_32bit | succeeded |
| run_science_unit_tests_ex1a_gnu_64bit | succeeded |
| run_simple_diffusion_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_simple_diffusion_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_simple_diffusion_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| run_simple_diffusion_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| run_simple_diffusion_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| run_simple_diffusion_unit_tests_azspice_gnu_64bit | succeeded |
| run_simple_diffusion_unit_tests_ex1a_gnu_64bit | succeeded |
| run_skeleton_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_skeleton_canned_ex1a_gnu_fast-debug-64bit | succeeded |
| run_skeleton_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| run_skeleton_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| run_skeleton_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| run_skeleton_unit_tests_azspice_gnu_64bit | succeeded |
| run_skeleton_unit_tests_ex1a_gnu_64bit | succeeded |
| site_validator | succeeded |
| style_checker | succeeded |
| validate_rose_meta | succeeded |
</details>


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (eg. PSyKAl-lite, Kernel
      interface, optimisation scripts, LFRic data structure code) then please
      contact the
      [tooscollabdevteam@metoffice.gov.uk](tooscollabdevteam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

_Please alert the code reviewer via a tag when you have approved the SR_

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
