### PR TITLE
Remove additional leading space from make message calls

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,5 +8,6 @@
 | mike-hobson     | Mike Hobson      | Met Office  | 2025-12-17 |
 | MatthewHambley  | Matthew Hambley  | Met Office  | 2025-12-15 |
 | yaswant         | Yaswant Pradhan  | Met Office  | 2025-12-16 |
-| harry-shepherd | Harry Shepherd | Met Office | 2026-01-08 |
+| harry-shepherd  | Harry Shepherd   | Met Office  | 2026-01-08 |
+| EdHone          | Ed Hone          | Met Office  | 2026-01-09 |
 

--- a/infrastructure/build/import.mk
+++ b/infrastructure/build/import.mk
@@ -39,7 +39,7 @@ import-infrastructure: $(WORKING_DIR)/field/field_real32_mod.f90 \
 
 $(WORKING_DIR)/field/field_%_mod.f90: $(LFRIC_INFRASTRUCTURE)/source/field/field_mod.t90 \
                                       | $(WORKING_DIR)/field
-	$(call MESSAGE, Templating, $<)
+	$(call MESSAGE,Templating, $<)
 	$Q$(TEMPLATE_TOOL) $< -o $@ -s type=$(TYPE_TABLE_$*) -s kind=$*
 
 $(WORKING_DIR)/field:
@@ -47,7 +47,7 @@ $(WORKING_DIR)/field:
 
 $(WORKING_DIR)/operator/operator_%_mod.f90: $(LFRIC_INFRASTRUCTURE)/source/operator/operator_mod.t90 \
                                             | $(WORKING_DIR)/operator
-	$(call MESSAGE, Templating, $<)
+	$(call MESSAGE,Templating, $<)
 	$Q$(TEMPLATE_TOOL) $< -o $@ -s kind=$*
 
 $(WORKING_DIR)/operator:
@@ -55,7 +55,7 @@ $(WORKING_DIR)/operator:
 
 $(WORKING_DIR)/scalar/scalar_%_mod.f90: $(LFRIC_INFRASTRUCTURE)/source/scalar/scalar_mod.t90 \
                                       | $(WORKING_DIR)/scalar
-	$(call MESSAGE, Templating, $<)
+	$(call MESSAGE,Templating, $<)
 	$Q$(TEMPLATE_TOOL) $< -o $@ -s type=$(TYPE_TABLE_$*) -s kind=$*
 
 $(WORKING_DIR)/scalar:

--- a/infrastructure/build/pfunit.mk
+++ b/infrastructure/build/pfunit.mk
@@ -38,12 +38,12 @@ $(WORKING_DIR)/%.F90: $(SOURCE_DIR)/%.pf
 	$(Q)$(PFUNIT)/bin/funitproc $(QUIET_ARG_SINGLE) $< $@
 
 $(WORKING_DIR)/%.F90: $(WORKING_DIR)/%.pf
-	$(call MESSAGE, Generating unit test, $@)
+	$(call MESSAGE,Generating unit test, $@)
 	$Qmkdir -p $(dir $@)
 	$Q$(PFUNIT)/bin/funitproc $(QUIET_ARG_SINGLE) $< $@
 
 $(WORKING_DIR)/%.pf: $(SOURCE_DIR)/%.PF
-	$(call MESSAGE, Preprocessing unit test, $<)
+	$(call MESSAGE,Preprocessing unit test, $<)
 	$Qmkdir -p $(dir $@)
 	$Q$(FPP) $(addprefix -I, $(PRE_PROCESS_INCLUDE_DIRS)) \
 	         $(addprefix -D, $(PRE_PROCESS_MACROS)) \

--- a/infrastructure/build/template.mk
+++ b/infrastructure/build/template.mk
@@ -20,11 +20,11 @@ SARGS = $(foreach key, $(SUBSTITUTIONS), $(foreach value, $(wordlist 2, 10, $(su
 generate-from-template: $(addprefix $(WORKING_DIR)/, $(FORTRAN_FILES))
 
 $(WORKING_DIR)/%.f90: $(SOURCE_DIR)/%.t90
-	$(call MESSAGE, Templating, $<)
+	$(call MESSAGE,Templating, $<)
 	$Q$(TOOL) $< -o $@ $(SARGS)
 
 $(WORKING_DIR)/%.F90: $(SOURCE_DIR)/%.T90
-	$(call MESSAGE, Templating, $<)
+	$(call MESSAGE,Templating, $<)
 	$Q$(TOOL) $< -o $@ $(SARGS)
 
 #include $(LFRIC_BUILD)/lfric.mk

--- a/infrastructure/build/tests.mk
+++ b/infrastructure/build/tests.mk
@@ -109,16 +109,16 @@ $$(if $$(realpath $$(TEST_DIR)/$$(dir $$*)/iodef.xml), $$(BIN_DIR)/$$(dir $$*)/i
 
 do-integration-tests/resources/%: \
 | $$(if $$(realpath $$(TEST_DIR)/support/resources), do-integration-tests/resources/support/$$*)
-	$(call MESSAGE, Harvesting, $*)
+	$(call MESSAGE,Harvesting, $*)
 	$Qif [ -e $(TEST_DIR)/$(dir $*)resources ]; then rsync -a $(TEST_DIR)/$(dir $*)resources $(BIN_DIR)/$(dir $*); fi
 
 do-integration-tests/resources/support/%: $(BIN_DIR)/resources
-	$(call MESSAGE, Symlinking to, support/resources)
+	$(call MESSAGE,Symlinking to, support/resources)
 	$Qmkdir -p $(BIN_DIR)/$(dir $*)
 	$Qln -sf $(BIN_DIR)/resources $(BIN_DIR)/$(dir $*)shared-resources
 
 $(BIN_DIR)/resources:
-	$(call MESSAGE, Harvesting, support/resources)
+	$(call MESSAGE,Harvesting, support/resources)
 	$Qrsync -a $(TEST_DIR)/support/resources $(BIN_DIR)/
 
 $(BIN_DIR)/%.py: $(TEST_DIR)/%.py
@@ -127,7 +127,7 @@ $(BIN_DIR)/%.py: $(TEST_DIR)/%.py
 	$Qcp $< $@
 
 $(BIN_DIR)%iodef.xml: $(TEST_DIR)%iodef.xml
-	$(call MESSAGE, Copying, $<)
+	$(call MESSAGE,Copying, $<)
 	$Qmkdir -p $(dir $@)
 	$Qcp $< $@
 


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: N/A
Code Reviewer: @MatthewHambley 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->
The number of leading spaces from Makefile messages across the code base is inconistent and annoying - this PR fixes this.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->
- closes #209 

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's
      [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the
      readability of the code
- [x] My changes generate no new warnings

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [x] If required (e.g. API changes) I have also run the LFRic Apps test suite
      using this branch
- [x] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (e.g. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (e.g. system
      tests, unit tests, etc.)
- [x] Any new tests have been assigned an appropriate amount of compute resource
      and have been allocated to an appropriate testing group (i.e. the
      developer tests are for jobs which use a small amount of compute resource
      and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log
# Test Suite Results - lfric_core - lfric_core-consistent-test-logging/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | lfric_core-consistent-test-logging/run1 |
| Suite User | edward.hone |
| Workflow Start | 2026-01-09T11:04:12 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [EdHone/lfric_core@consistent-test-logging](https://github.com/EdHone/lfric_core/tree/consistent-test-logging) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2025.12.1](https://github.com/MetOffice/SimSys_Scripts/tree/2025.12.1) | True |

## Task Information
<details>
<summary>:white_check_mark: succeeded tasks - 372</summary>

| Task | State |
| :--- | :--- |
| build_coupled_azspice_gnu_fast-debug-64bit | succeeded |
| build_coupled_azspice_gnu_full-debug-64bit | succeeded |
| build_coupled_ex1a_cce_fast-debug-64bit | succeeded |
| build_coupled_ex1a_cce_full-debug-64bit | succeeded |
| build_coupling_unit_tests_azspice_gnu_32bit | succeeded |
| build_coupling_unit_tests_azspice_gnu_64bit | succeeded |
| build_coupling_unit_tests_ex1a_gnu_32bit | succeeded |
| build_coupling_unit_tests_ex1a_gnu_64bit | succeeded |
| build_driver_unit_tests_azspice_gnu_32bit | succeeded |
| build_driver_unit_tests_azspice_gnu_64bit | succeeded |
| build_driver_unit_tests_ex1a_gnu_32bit | succeeded |
| build_driver_unit_tests_ex1a_gnu_64bit | succeeded |
| build_infrastructure_integration_tests_azspice_gnu_32bit | succeeded |
| build_infrastructure_integration_tests_azspice_gnu_64bit | succeeded |
| build_infrastructure_integration_tests_ex1a_cce_32bit | succeeded |
| build_infrastructure_integration_tests_ex1a_cce_64bit | succeeded |
| build_infrastructure_unit_tests_azspice_gnu_32bit | succeeded |
| build_infrastructure_unit_tests_azspice_gnu_64bit | succeeded |
| build_infrastructure_unit_tests_ex1a_gnu_32bit | succeeded |
| build_infrastructure_unit_tests_ex1a_gnu_64bit | succeeded |
| build_io_demo_azspice_gnu_fast-debug-32bit | succeeded |
| build_io_demo_azspice_gnu_fast-debug-64bit | succeeded |
| build_io_demo_azspice_gnu_full-debug-64bit | succeeded |
| build_io_demo_ex1a_cce_fast-debug-32bit | succeeded |
| build_io_demo_ex1a_cce_fast-debug-64bit | succeeded |
| build_io_demo_ex1a_cce_full-debug-64bit | succeeded |
| build_io_demo_ex1a_gnu_fast-debug-32bit | succeeded |
| build_io_demo_ex1a_gnu_fast-debug-64bit | succeeded |
| build_io_demo_unit_tests_azspice_gnu_64bit | succeeded |
| build_io_demo_unit_tests_ex1a_gnu_64bit | succeeded |
| build_lbc_demo_azspice_gnu_fast-debug-64bit | succeeded |
| build_lbc_demo_azspice_gnu_full-debug-64bit | succeeded |
| build_lbc_demo_ex1a_cce_fast-debug-64bit | succeeded |
| build_lbc_demo_ex1a_gnu_fast-debug-64bit | succeeded |
| build_lfric_xios_integration_tests_azspice_gnu_64bit | succeeded |
| build_lfric_xios_integration_tests_ex1a_cce_64bit | succeeded |
| build_lfric_xios_unit_tests_azspice_gnu_64bit | succeeded |
| build_lfric_xios_unit_tests_ex1a_gnu_64bit | succeeded |
| build_mesh_azspice_gnu_fast-debug-64bit | succeeded |
| build_mesh_ex1a_gnu_fast-debug-64bit | succeeded |
| build_mesh_tools_azspice_gnu_fast-debug-64bit | succeeded |
| build_mesh_tools_azspice_gnu_full-debug-64bit | succeeded |
| build_mesh_tools_ex1a_cce_fast-debug-64bit | succeeded |
| build_mesh_tools_ex1a_cce_full-debug-64bit | succeeded |
| build_mesh_tools_ex1a_gnu_fast-debug-64bit | succeeded |
| build_mesh_tools_unit_tests_azspice_gnu_64bit | succeeded |
| build_mesh_tools_unit_tests_ex1a_gnu_64bit | succeeded |
| build_science_unit_tests_azspice_gnu_32bit | succeeded |
| build_science_unit_tests_azspice_gnu_64bit | succeeded |
| build_science_unit_tests_ex1a_gnu_32bit | succeeded |
| build_science_unit_tests_ex1a_gnu_64bit | succeeded |
| build_simple_diffusion_azspice_gnu_fast-debug-64bit | succeeded |
| build_simple_diffusion_azspice_gnu_full-debug-64bit | succeeded |
| build_simple_diffusion_ex1a_cce_fast-debug-64bit | succeeded |
| build_simple_diffusion_ex1a_cce_full-debug-64bit | succeeded |
| build_simple_diffusion_ex1a_gnu_full-debug-64bit | succeeded |
| build_simple_diffusion_unit_tests_azspice_gnu_64bit | succeeded |
| build_simple_diffusion_unit_tests_ex1a_gnu_64bit | succeeded |
| build_skeleton_azspice_gnu_fast-debug-64bit | succeeded |
| build_skeleton_azspice_gnu_full-debug-64bit | succeeded |
| build_skeleton_ex1a_cce_full-debug-64bit | succeeded |
| build_skeleton_ex1a_gnu_fast-debug-64bit | succeeded |
| build_skeleton_ex1a_gnu_full-debug-64bit | succeeded |
| build_skeleton_unit_tests_azspice_gnu_64bit | succeeded |
| build_skeleton_unit_tests_ex1a_gnu_64bit | succeeded |
| check_coupled_default-C12_azspice_gnu_fast-debug-64bit | succeeded |
| check_coupled_default-C12_azspice_gnu_full-debug-64bit | succeeded |
| check_coupled_default-C12_ex1a_cce_fast-debug-64bit | succeeded |
| check_coupled_default-C12_ex1a_cce_full-debug-64bit | succeeded |
| check_io_demo_default-C24_azspice_gnu_fast-debug-32bit | succeeded |
| check_io_demo_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| check_io_demo_default-C24_ex1a_cce_fast-debug-32bit | succeeded |
| check_io_demo_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| check_io_demo_multifile-C24_azspice_gnu_fast-debug-32bit | succeeded |
| check_io_demo_multifile-C24_azspice_gnu_fast-debug-64bit | succeeded |
| check_io_demo_multifile-C24_ex1a_cce_fast-debug-32bit | succeeded |
| check_io_demo_multifile-C24_ex1a_cce_fast-debug-64bit | succeeded |
| check_io_demo_multifile-C24_ex1a_gnu_fast-debug-32bit | succeeded |
| check_io_demo_multifile-C24_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_ConstantLBC-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_OutputOnLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| check_lbc_demo_default-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c1_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c1_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c1_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c2_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c2_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c2_ex1a_cce_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c3_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c3_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-c3_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-maps_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-maps_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-maps_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op-nonuniform_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-op_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-rotated_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-rotated_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere-rotated_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_cubedsphere_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_equator-band_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_equator-band_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_equator-band_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_equator_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_equator_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_equator_ex1a_cce_full-debug-64bit | succeeded |
| check_mesh_tools_falklands_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_falklands_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_falklands_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_lam_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_lam_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_lam_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_london-model_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_london-model_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_london-model_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_nzlam4_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_nzlam4_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_nzlam4_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-bi-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-bi-periodic_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-bi-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-lbc_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-maps_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-maps_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-maps_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-non-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-non-periodic_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-non-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-op-lam_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-op-lam_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-op-lam_ex1a_cce_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-centres_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-centres_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-centres_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-nodes_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-nodes_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-nodes_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-points_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-points_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-stretch-points_ex1a_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-x_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-x_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-x_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-y_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-y_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_planar-trench-y_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_polar_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_polar_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_polar_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_uk_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_uk_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_uk_ex1a_cce_fast-debug-64bit | succeeded |
| check_mesh_tools_var-seuk_azspice_gnu_fast-debug-64bit | succeeded |
| check_mesh_tools_var-seuk_azspice_gnu_full-debug-64bit | succeeded |
| check_mesh_tools_var-seuk_ex1a_gnu_fast-debug-64bit | succeeded |
| check_simple_diffusion_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| check_simple_diffusion_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| check_simple_diffusion_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| check_skeleton_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| check_skeleton_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| check_skeleton_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| config_dump_checker | succeeded |
| export-source | succeeded |
| export-source_azspice | succeeded |
| export-source_ex1a | succeeded |
| global_variables_checker | succeeded |
| housekeep_azspice | succeeded |
| housekeep_ex1a | succeeded |
| python_unit_tests | succeeded |
| remote-init_azspice | succeeded |
| remote-init_ex1a | succeeded |
| rose-stem_lint_checker | succeeded |
| run_coupled_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_coupled_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_coupled_default-C12_azspice_gnu_fast-debug-64bit | succeeded |
| run_coupled_default-C12_azspice_gnu_full-debug-64bit | succeeded |
| run_coupled_default-C12_ex1a_cce_fast-debug-64bit | succeeded |
| run_coupled_default-C12_ex1a_cce_full-debug-64bit | succeeded |
| run_coupling_unit_tests_azspice_gnu_32bit | succeeded |
| run_coupling_unit_tests_azspice_gnu_64bit | succeeded |
| run_coupling_unit_tests_ex1a_gnu_32bit | succeeded |
| run_coupling_unit_tests_ex1a_gnu_64bit | succeeded |
| run_driver_unit_tests_azspice_gnu_32bit | succeeded |
| run_driver_unit_tests_azspice_gnu_64bit | succeeded |
| run_driver_unit_tests_ex1a_gnu_32bit | succeeded |
| run_driver_unit_tests_ex1a_gnu_64bit | succeeded |
| run_infrastructure_integration_tests_azspice_gnu_32bit | succeeded |
| run_infrastructure_integration_tests_azspice_gnu_64bit | succeeded |
| run_infrastructure_integration_tests_ex1a_cce_32bit | succeeded |
| run_infrastructure_integration_tests_ex1a_cce_64bit | succeeded |
| run_infrastructure_unit_tests_azspice_gnu_32bit | succeeded |
| run_infrastructure_unit_tests_azspice_gnu_64bit | succeeded |
| run_infrastructure_unit_tests_ex1a_gnu_32bit | succeeded |
| run_infrastructure_unit_tests_ex1a_gnu_64bit | succeeded |
| run_io_demo_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_io_demo_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_io_demo_default-C24_azspice_gnu_fast-debug-32bit | succeeded |
| run_io_demo_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| run_io_demo_default-C24_ex1a_cce_fast-debug-32bit | succeeded |
| run_io_demo_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| run_io_demo_multifile-C24_azspice_gnu_fast-debug-32bit | succeeded |
| run_io_demo_multifile-C24_azspice_gnu_fast-debug-64bit | succeeded |
| run_io_demo_multifile-C24_ex1a_cce_fast-debug-32bit | succeeded |
| run_io_demo_multifile-C24_ex1a_cce_fast-debug-64bit | succeeded |
| run_io_demo_multifile-C24_ex1a_gnu_fast-debug-32bit | succeeded |
| run_io_demo_multifile-C24_ex1a_gnu_fast-debug-64bit | succeeded |
| run_io_demo_unit_tests_azspice_gnu_64bit | succeeded |
| run_io_demo_unit_tests_ex1a_gnu_64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_ConstantLBC-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_IntegerFields-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_1x1P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_2x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_8x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_OutputOnLBC-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_lbc_demo_default-lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_lfric_xios_integration_tests_azspice_gnu_64bit | succeeded |
| run_lfric_xios_integration_tests_ex1a_cce_64bit | succeeded |
| run_lfric_xios_unit_tests_azspice_gnu_64bit | succeeded |
| run_lfric_xios_unit_tests_ex1a_gnu_64bit | succeeded |
| run_mesh_C12_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_C12_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_C24_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_C24_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_LAM50x50-2x2_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_LAM50x50-2x2_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_1x1P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_2x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_8x2P_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_lbc_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_canned_cubedsphere_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_canned_planar_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c1_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c1_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c1_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c2_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c2_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c2_ex1a_cce_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c3_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c3_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-c3_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-maps_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-maps_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-maps_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op-nonuniform_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op-nonuniform_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-op_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-rotated_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-rotated_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere-rotated_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_cubedsphere_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_equator-band_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_equator-band_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_equator-band_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_equator_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_equator_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_equator_ex1a_cce_full-debug-64bit | succeeded |
| run_mesh_tools_falklands_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_falklands_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_falklands_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_lam_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_lam_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_lam_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_london-model_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_london-model_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_london-model_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_nzlam4_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_nzlam4_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_nzlam4_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-bi-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-bi-periodic_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-bi-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-lbc_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-lbc_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-lbc_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-maps_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-maps_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-maps_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-non-periodic_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-non-periodic_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-non-periodic_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-op-lam_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-op-lam_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-op-lam_ex1a_cce_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-centres_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-centres_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-centres_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-nodes_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-nodes_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-nodes_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-points_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-points_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-stretch-points_ex1a_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-x_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-x_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-x_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-y_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-y_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_planar-trench-y_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_polar_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_polar_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_polar_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_uk_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_uk_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_uk_ex1a_cce_fast-debug-64bit | succeeded |
| run_mesh_tools_unit_tests_azspice_gnu_64bit | succeeded |
| run_mesh_tools_unit_tests_ex1a_gnu_64bit | succeeded |
| run_mesh_tools_var-seuk_azspice_gnu_fast-debug-64bit | succeeded |
| run_mesh_tools_var-seuk_azspice_gnu_full-debug-64bit | succeeded |
| run_mesh_tools_var-seuk_ex1a_gnu_fast-debug-64bit | succeeded |
| run_science_unit_tests_azspice_gnu_32bit | succeeded |
| run_science_unit_tests_azspice_gnu_64bit | succeeded |
| run_science_unit_tests_ex1a_gnu_32bit | succeeded |
| run_science_unit_tests_ex1a_gnu_64bit | succeeded |
| run_simple_diffusion_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_simple_diffusion_canned_ex1a_cce_fast-debug-64bit | succeeded |
| run_simple_diffusion_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| run_simple_diffusion_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| run_simple_diffusion_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| run_simple_diffusion_unit_tests_azspice_gnu_64bit | succeeded |
| run_simple_diffusion_unit_tests_ex1a_gnu_64bit | succeeded |
| run_skeleton_canned_azspice_gnu_fast-debug-64bit | succeeded |
| run_skeleton_canned_ex1a_gnu_fast-debug-64bit | succeeded |
| run_skeleton_default-C24_azspice_gnu_full-debug-64bit | succeeded |
| run_skeleton_default-C24_ex1a_cce_full-debug-64bit | succeeded |
| run_skeleton_default-C24_ex1a_gnu_full-debug-64bit | succeeded |
| run_skeleton_unit_tests_azspice_gnu_64bit | succeeded |
| run_skeleton_unit_tests_ex1a_gnu_64bit | succeeded |
| site_validator | succeeded |
| style_checker | succeeded |
| validate_rose_meta | succeeded |
</details>


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel
      interface, optimisation scripts, LFRic data structure code) then please
      contact the
      [tooscollabdevteam@metoffice.gov.uk](tooscollabdevteam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

_Please alert the code reviewer via a tag when you have approved the SR_

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
