### PR TITLE
run remote_init on shared

### DIFF
--- a/rose-stem/site/meto/common/suite_config_ex1a.cylc
+++ b/rose-stem/site/meto/common/suite_config_ex1a.cylc
@@ -158,6 +158,16 @@
             PLATFORM_SYNC = true
 {% endif %}
 
+    [[EX1A_REMOTE_INIT]]
+        inherit = EX1A_BASE
+        [[[directives]]]
+{% if site_vars["ex_trustzone"] == "collab" %}
+            -q = collabshared
+{% else %}
+            -q = shared
+{% endif %}
+            -l ncpus=1
+
     [[EX1A_HOUSEKEEPING]]
         inherit=EX1A_TECH_BASE
 

--- a/rose-stem/site/meto/variables.cylc
+++ b/rose-stem/site/meto/variables.cylc
@@ -45,6 +45,8 @@
 {% do site_vars.update({"mesh_build": {"ex1a": "gnu_fast-debug-64bit",
                                        "azspice": "gnu_fast-debug-64bit"} }) %}
 
+{% do site_vars.update({"remote_init_family": {"ex1a": "EX1A_REMOTE_INIT"} }) %}
+
 {# Choose EX Host - default to random ab or cd #}
 {% if site_vars["ex_trustzone"] == "collab" %}
     {% do site_vars.update({"host_ex" : "ex"}) %}

--- a/rose-stem/templates/runtime/generate_runtime_control.cylc
+++ b/rose-stem/templates/runtime/generate_runtime_control.cylc
@@ -85,8 +85,14 @@
 
     {% set platform = task.split('_')[1] %}
 
+    {% if "remote_init_family" in site_vars and platform in site_vars["remote_init_family"] %}
+        {% set remote_inherit = "EXPORT-SOURCE, "~site_vars["remote_init_family"][platform]~", CONTROL_TASK_RETRIES" %}
+    {% else %}
+        {% set remote_inherit = "EXPORT-SOURCE, "~platform|upper~"_BASE, CONTROL_TASK_RETRIES" %}
+    {% endif %}
+
     [[{{task}}]]
-        inherit = EXPORT-SOURCE, {{platform|upper}}_BASE
+        inherit = {{remote_inherit}}
         script = true
         execution time limit = PT1M
 


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @mo-marqh 

<!-- To be completed by the developer -->

Changes the remote_init_ex1a task to run on the shared queue

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

Job running on the shared queue can be seen at https://cylchub/services/cylc-review/view/james.bruten?&suite=remote_init_shared_core%2Frun1&no_fuzzy_time=0&path=log/job/1/remote-init_ex1a/01/job

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [x] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [x] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
