### PR TITLE
Null island left as uninitialised value for planar non-spherical meshes

### DIFF
--- a/infrastructure/source/io/ugrid_2d_mod.F90
+++ b/infrastructure/source/io/ugrid_2d_mod.F90
@@ -125,7 +125,7 @@ type, public :: ugrid_2d_type
   ! Information about the domain orientation
   real(r_def) :: north_pole(2)        !< [Longitude, Latitude] of north pole used
                                       !< for the domain orientation (degrees)
-  real(r_def) :: null_island(2)       !< [Longitude, Latitude] of null island
+  real(r_def) :: null_island(2) = rmdi !< [Longitude, Latitude] of null island
                                       !< used for the domain orientation (degrees)
   real(r_def) :: equatorial_latitude  !< Latitude of equator of mesh (degrees)
 

--- a/infrastructure/source/mesh/global_mesh_mod.F90
+++ b/infrastructure/source/mesh/global_mesh_mod.F90
@@ -272,7 +272,7 @@ contains
     character(str_def) :: topology
     character(str_def) :: coord_sys
 
-    integer(i_def) :: null_island(2)
+    real(r_def) :: null_island(2)
 
     ! loop counter over entities (vertices or edges).
     integer(i_def) :: ientity
@@ -347,7 +347,7 @@ contains
     end select
 
     ! null island will exist only on a spherical lat-lon mesh
-    if (is_geometry_spherical .and. is_coord_sys_ll) then
+    if ( self%is_geometry_spherical() .and. self%is_coord_sys_ll() ) then
       self%null_island = null_island
     end if
 

--- a/infrastructure/source/mesh/global_mesh_mod.F90
+++ b/infrastructure/source/mesh/global_mesh_mod.F90
@@ -73,11 +73,11 @@ module global_mesh_mod
     real(r_def) :: domain_extents(2,4) = rmdi
 
   ! Real-world location of mesh North Pole,
-  ! only valid for spherical geometry on lon-lat cordinate-system.
+  ! only valid for spherical geometry on lon-lat coordinate-system.
     real(r_def) :: north_pole(2) = rmdi
 
   ! Real-world location of mesh null island,
-  ! only valid for spherical geometry on lon-lat cordinate-system.
+  ! only valid for spherical geometry on lon-lat coordinate-system.
     real(r_def) :: null_island(2) = rmdi
 
   ! Latitude of equator of mesh following stretching
@@ -272,6 +272,8 @@ contains
     character(str_def) :: topology
     character(str_def) :: coord_sys
 
+    integer(i_def) :: null_island(2)
+
     ! loop counter over entities (vertices or edges).
     integer(i_def) :: ientity
 
@@ -294,7 +296,7 @@ contains
                                    self%cell_coords, &
                                    self%coord_units_xy, &
                                    self%north_pole, &
-                                   self%null_island, &
+                                   null_island, &
                                    self%equatorial_latitude, &
                                    self%constructor_inputs, &
                                    self%rim_depth, &
@@ -344,6 +346,10 @@ contains
 
     end select
 
+    ! null island will exist only on a spherical lat-lon mesh
+    if (is_geometry_spherical .and. is_coord_sys_ll) then
+      self%null_island = null_island
+    end if
 
     ! CF Standard for longitude/latitude is in degrees
     ! though many functions assume radians. Convert


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: 
Code Reviewer: @mo-rickywong 

A planar biperiodic mesh has no null island value defined, but there is no default value for null_island in ugrid_2d_mod. This occasionally caused numerical errors running the lfric_atm/example test, and has been seen in testing at STFC.

When global_mesh_mod reads the mesh file, the uninitialised value in ugrid_2d overwrites the value in global_mesh which had been initialised to RMDI.

This PR adds consistent initialisation of null_island to ugrid_2d.

It also goes a step towards not automatically dumping everything from ugrid_2d into global_mesh by copying the null_island value only if the mesh is spherical and on lat-lon coordinates. One could go farther with this approach, but I don't want to expand the remit of this bug fix.

While the lfric_core test suite provides reasonable coverage, I also tested the change with lfric_apps developer suite.

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [x] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log
# Test Suite Results - lfric_core - null_island2_core/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [null_island2_core/run1](https://cylchub/services/cylc-review/cycles/steve.mullerworth/?suite=null_island2_core%2Frun1) |
| Suite User | steve.mullerworth |
| Workflow Start | 2026-03-27T14:59:51 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [stevemullerworth/lfric_core@null_island2](https://github.com/stevemullerworth/lfric_core/tree/null_island2) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@4387949](https://github.com/MetOffice/SimSys_Scripts/tree/4387949) | True |

## Task Information
:white_check_mark: succeeded tasks - 388

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
