### PR TITLE
Replace sleep intrinsic with C bindings

### DIFF
--- a/applications/io_demo/build/project.mk
+++ b/applications/io_demo/build/project.mk
@@ -8,5 +8,3 @@
 # via the Makefile.
 
 $(info io_demo miniapp project specials)
-# Enable the use of the sleep() intrinsic for gfortran
-export FFLAGS_GNU_OPTIONS = -fall-intrinsics

--- a/applications/io_demo/source/driver/io_benchmark/io_benchmark_step_mod.x90
+++ b/applications/io_demo/source/driver/io_benchmark/io_benchmark_step_mod.x90
@@ -17,6 +17,7 @@ module io_benchmark_step_mod
   use log_mod,              only: log_event,         &
                                   log_scratch_space, &
                                   LOG_LEVEL_INFO
+  use sleep_mod,            only: c_sleep
 
   implicit none
 
@@ -69,7 +70,7 @@ contains
 
       write(log_scratch_space,'(A,I0,A)') "io_demo: sleeping for ", sleep_duration, " seconds"
       call log_event(log_scratch_space, LOG_LEVEL_INFO)
-      call sleep(sleep_duration)
+      call c_sleep(sleep_duration)
 
       nullify(step_field)
       nullify(kernel_field)

--- a/infrastructure/build/fortran/gfortran.mk
+++ b/infrastructure/build/fortran/gfortran.mk
@@ -44,9 +44,6 @@ FFLAGS_FASTD_RUNTIME      = $(FFLAGS_RUNTIME)
 # Option for checking code meets Fortran standard - currently 2008
 FFLAGS_FORTRAN_STANDARD   = -std=f2008
 
-# Add compiler-specific project option
-FFLAGS_COMPILER += $(FFLAGS_GNU_OPTIONS)
-
 LDFLAGS_COMPILER =
 
 utilities/traceback_mod.o utilities/traceback_mod.mod: private FFLAGS_EXTRA = -fall-intrinsics

--- a/infrastructure/source/utilities/sleep_mod.f90
+++ b/infrastructure/source/utilities/sleep_mod.f90
@@ -1,3 +1,9 @@
+!-----------------------------------------------------------------------------
+! (C) Crown copyright Met Office. All rights reserved.
+! For further details please refer to the file LICENCE which you should have
+! received as part of this distribution.
+!-----------------------------------------------------------------------------
+
 !> Module containing an interface to the sleep and usleep utilities from C.
 module sleep_mod
 

--- a/infrastructure/source/utilities/sleep_mod.f90
+++ b/infrastructure/source/utilities/sleep_mod.f90
@@ -13,34 +13,26 @@ module sleep_mod
   implicit none
 
   private
-  public :: sleep, usleep
+  public :: c_sleep
 
   !> Interface to the C usleep function
   interface
-    function c_usleep(useconds) bind(c, name='usleep')
+    function bind_c_usleep(useconds) bind(c, name='usleep')
         import :: c_int, c_int32_t
         implicit none
         integer(kind=c_int32_t), value :: useconds
-        integer(kind=c_int)            :: c_usleep
-    end function c_usleep
+        integer(kind=c_int)            :: bind_c_usleep
+    end function bind_c_usleep
   end interface
 
 contains
 
   !> Sleep for a given number of seconds
   !> @param seconds Number of seconds to sleep
-  subroutine sleep(seconds)
+  subroutine c_sleep(seconds)
       integer(i_def), intent(in) :: seconds
       integer(kind=c_int) :: rc
-      rc = c_usleep(int(seconds, kind=c_int32_t) * 1000000_c_int32_t )
-  end subroutine sleep
-
-  !> Sleep for a given number of microseconds
-  !> @param microseconds Number of microseconds to sleep
-  subroutine usleep(microseconds)
-      integer(i_def), intent(in) :: microseconds
-      integer(kind=c_int) :: rc
-      rc = c_usleep(int(microseconds, kind=c_int32_t))
-  end subroutine usleep
+      rc = bind_c_usleep(int(seconds, kind=c_int32_t) * 1000000_c_int32_t )
+  end subroutine c_sleep
 
 end module sleep_mod

--- a/infrastructure/source/utilities/sleep_mod.f90
+++ b/infrastructure/source/utilities/sleep_mod.f90
@@ -4,7 +4,7 @@
 ! received as part of this distribution.
 !-----------------------------------------------------------------------------
 
-!> Module containing an interface to the sleep and usleep utilities from C.
+!> Module containing an interface to the usleep utility from C.
 module sleep_mod
 
   use, intrinsic :: iso_c_binding, only : c_int, c_int32_t

--- a/infrastructure/source/utilities/sleep_mod.f90
+++ b/infrastructure/source/utilities/sleep_mod.f90
@@ -1,0 +1,40 @@
+!> Module containing an interface to the sleep and usleep utilities from C.
+module sleep_mod
+
+  use, intrinsic :: iso_c_binding, only : c_int, c_int32_t
+  use constants_mod, only: i_def
+
+  implicit none
+
+  private
+  public :: sleep, usleep
+
+  !> Interface to the C usleep function
+  interface
+    function c_usleep(useconds) bind(c, name='usleep')
+        import :: c_int, c_int32_t
+        implicit none
+        integer(kind=c_int32_t), value :: useconds
+        integer(kind=c_int)            :: c_usleep
+    end function c_usleep
+  end interface
+
+contains
+
+  !> Sleep for a given number of seconds
+  !> @param seconds Number of seconds to sleep
+  subroutine sleep(seconds)
+      integer(i_def), intent(in) :: seconds
+      integer(kind=c_int) :: rc
+      rc = c_usleep(int(seconds, kind=c_int32_t) * 1000000_c_int32_t )
+  end subroutine sleep
+
+  !> Sleep for a given number of microseconds
+  !> @param microseconds Number of microseconds to sleep
+  subroutine usleep(microseconds)
+      integer(i_def), intent(in) :: microseconds
+      integer(kind=c_int) :: rc
+      rc = c_usleep(int(microseconds, kind=c_int32_t))
+  end subroutine usleep
+
+end module sleep_mod

--- a/infrastructure/unit-test/utilities/timer_mod_test.pf
+++ b/infrastructure/unit-test/utilities/timer_mod_test.pf
@@ -13,6 +13,7 @@ module timer_mod_test
   use lfric_mpi_mod, only : global_mpi, &
                             lfric_comm_type
   use constants_mod, only : r_def, i_def, str_def, r_double, i_long
+  use sleep_mod,     only : sleep
 
   implicit none
 

--- a/infrastructure/unit-test/utilities/timer_mod_test.pf
+++ b/infrastructure/unit-test/utilities/timer_mod_test.pf
@@ -13,7 +13,7 @@ module timer_mod_test
   use lfric_mpi_mod, only : global_mpi, &
                             lfric_comm_type
   use constants_mod, only : r_def, i_def, str_def, r_double, i_long
-  use sleep_mod,     only : sleep
+  use sleep_mod,     only : c_sleep
 
   implicit none
 
@@ -121,7 +121,7 @@ contains
 
     call init_timer()
     call timer('test_sleep')
-    call sleep(1)
+    call c_sleep(1)
     call timer('test_sleep')
     call calculate_timer_stats()
     val = get_mean_time(1)


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: 
Code Reviewer: @MatthewHambley 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

This PR replaces the use of the `sleep` Fortran intrinsic with a new routine which binds to the C `usleep` function with `iso_c_bindings`. Additional compiler options that were switched on to enable the use of the intrinsic (such as in #232) have been disabled.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

Closes #241 

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_core - lfric_core-c-sleep/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [lfric_core-c-sleep/run1](https://cylchub/services/cylc-review/cycles/edward.hone/?suite=lfric_core-c-sleep%2Frun1) |
| Suite User | edward.hone |
| Workflow Start | 2026-03-31T09:21:13 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [EdHone/lfric_core@c-sleep](https://github.com/EdHone/lfric_core/tree/c-sleep) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@4387949](https://github.com/MetOffice/SimSys_Scripts/tree/4387949) | True |

## Task Information
:white_check_mark: succeeded tasks - 390


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
