### PR TITLE
Reformat stop calls to avoid model stopping without error code

### DIFF
--- a/components/science/source/algorithm/sci_fem_constants_mod.x90
+++ b/components/science/source/algorithm/sci_fem_constants_mod.x90
@@ -259,7 +259,6 @@ contains
       case default
         mm_op => null()
         call log_event("Mass matrix operator does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -372,7 +371,6 @@ contains
       case default
         mm_op => null()
         call log_event("Mass matrix operator does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -477,7 +475,6 @@ contains
       case default
         diagonal_mm => null()
         call log_event("Diagonal mass matrix operator does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -552,7 +549,6 @@ contains
       case default
         diagonal_mm => null()
         call log_event("Diagonal mass matrix operator does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -623,7 +619,6 @@ contains
       case default
         mm_linv => null()
         call log_event("Lumped inverse mass matrix does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -702,7 +697,6 @@ contains
       case default
         mm_linv => null()
         call log_event("Lumped inverse mass matrix does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -783,7 +777,6 @@ contains
       case default
         mm_inv => null()
         call log_event("Inverse mass matrix operator does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -847,7 +840,6 @@ contains
       case default
         mm_inv => null()
         call log_event("Inverse mass matrix operator does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -1240,7 +1232,6 @@ contains
       case default
         rmultiplicity => null()
         call log_event( "Reciprocal multiplicity field does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant
@@ -1314,7 +1305,6 @@ contains
       case default
         rmultiplicity => null()
         call log_event( "Reciprocal multiplicity field does not exist", LOG_LEVEL_ERROR)
-        stop
     end select
 
     ! Initialise inventory if this is the first time getting this constant

--- a/infrastructure/build/tools/configurator/templates/config_loader.f90.jinja
+++ b/infrastructure/build/tools/configurator/templates/config_loader.f90.jinja
@@ -70,7 +70,7 @@ contains
           'At least one optional argument must ' //&
           'be provided for read_configuration.'
       flush(error_unit)
-      stop
+      stop 1
     end if
 
     local_rank = global_mpi%get_comm_rank()
@@ -186,7 +186,7 @@ contains
           'Arguments "names" and "success_mask" to function' //&
           '"ensure_configuration" are different shapes.'
       flush(error_unit)
-      stop
+      stop 1
     end if
 
     ensure_configuration = .true.
@@ -203,7 +203,7 @@ contains
             'Tried to ensure unrecognised namelist "' //&
             trim(names(i))//'" was loaded.'
         flush(error_unit)
-        stop
+        stop 1
       end select
 
       ensure_configuration = ensure_configuration .and. configuration_found
@@ -278,7 +278,7 @@ contains
                 'Namelist "'//trim(namelists(i)) //&
                 '" can not be read. Too many instances?'
             flush(error_unit)
-            stop
+            stop 1
           end if
 {%- endfor %}
 
@@ -287,7 +287,7 @@ contains
               'Unrecognised namelist "'//trim(namelists(i)) //&
               '" found in file '//trim(filename)//'.'
           flush(error_unit)
-          stop
+          stop 1
         end select
 
       end do ! Namelists

--- a/infrastructure/build/tools/configurator/templates/config_type.f90.jinja
+++ b/infrastructure/build/tools/configurator/templates/config_type.f90.jinja
@@ -107,7 +107,7 @@ subroutine initialise(self, name)
          trim(self%config_name) //&
         '] has already been initialised.'
     flush(error_unit)
-    stop
+    stop 1
   end if
 
   if (present(name)) then
@@ -160,7 +160,7 @@ subroutine add_namelist(self, namelist_obj)
       write(error_unit, '(A)') &
           trim(name) // ' namelist already allocated.'
       flush(error_unit)
-      stop
+      stop 1
     else
       allocate(self%{{namelists[i]}}, source=namelist_obj)
       call self%update_contents(trim(name))
@@ -180,7 +180,7 @@ subroutine add_namelist(self, namelist_obj)
       write(error_unit, '(A)') trim(name) //&
           ' namelist (' // trim(profile_name) // '), already allocated.'
       flush(error_unit)
-      stop
+      stop 1
     else
       call self%{{namelists[i]}}%insert_item( namelist_obj )
       call self%update_contents(namelist_obj%get_full_name())
@@ -192,7 +192,7 @@ subroutine add_namelist(self, namelist_obj)
         ' Undefined namelist type(' // trim(name) //&
         '), for this configuration.'
     flush(error_unit)
-    stop
+    stop 1
 
   end select
 
@@ -277,7 +277,7 @@ function {{namelists[i]}}_list(self, profile_name) result({{namelists[i]}}_nml_o
           '{{namelists[i]}}_nml_type ' //&
           'not found in configuration.'
       flush(error_unit)
-      stop
+      stop 1
     end if
 
     ! Otherwise 'cast' to a {{namelists[i]}}_namelist_type

--- a/infrastructure/build/tools/configurator/templates/feign_config.f90.jinja
+++ b/infrastructure/build/tools/configurator/templates/feign_config.f90.jinja
@@ -88,7 +88,7 @@ contains
 
     if (condition /= 0) then
       write( 6, '("feign_{{name}}_config: ", I0)' ) condition
-      stop
+      stop 1
     end if
 
     write( temporary_unit, '("&{{name}}")' )
@@ -127,7 +127,7 @@ contains
     call read_{{name}}_namelist( temporary_unit, local_rank, scan=.false. )
     call postprocess_{{name}}_namelist()
     close(temporary_unit, iostat=condition )
-    if (condition /= 0) stop temp_close_message
+    if (condition /= 0) error stop temp_close_message
 
   end subroutine feign_{{name}}_config
 {%- endfor %}

--- a/infrastructure/build/tools/configurator/templates/namelist_loader.f90.jinja
+++ b/infrastructure/build/tools/configurator/templates/namelist_loader.f90.jinja
@@ -144,7 +144,7 @@ contains
               'Key ' // trim(adjustl(key)) // ' not recognised for ' // &
               '{{name}} in {{listname}} namelist.'
           flush(error_unit)
-          stop
+          stop 1
         end if
       end if
     end do
@@ -270,7 +270,7 @@ contains
       write(error_unit, '(A)') &
           'Unable to allocate temporary array for "{{name}}"'
       flush(error_unit)
-      stop
+      stop 1
     end if
 {%-     endif %}
 {%-   endfor %}
@@ -301,7 +301,7 @@ contains
       if (condition /= 0) then
         write(error_unit, '(A)') trim(log_scratch_space)
         flush(error_unit)
-        stop
+        stop 1
       end if
 
 {%- for name in enumerations | sort %}

--- a/infrastructure/build/tools/configurator/tests/app_config/content_mod.f90
+++ b/infrastructure/build/tools/configurator/tests/app_config/content_mod.f90
@@ -96,7 +96,7 @@ subroutine initialise(self, name)
          trim(self%config_name) //&
         '] has already been initialised.'
     flush(error_unit)
-    stop
+    stop 1
   end if
 
   if (present(name)) then
@@ -144,7 +144,7 @@ subroutine add_namelist(self, namelist_obj)
       write(error_unit, '(A)') &
           trim(name) // ' namelist already allocated.'
       flush(error_unit)
-      stop
+      stop 1
     else
       allocate(self%foo, source=namelist_obj)
       call self%update_contents(trim(name))
@@ -156,7 +156,7 @@ subroutine add_namelist(self, namelist_obj)
       write(error_unit, '(A)') &
           trim(name) // ' namelist already allocated.'
       flush(error_unit)
-      stop
+      stop 1
     else
       allocate(self%moo, source=namelist_obj)
       call self%update_contents(trim(name))
@@ -172,7 +172,7 @@ subroutine add_namelist(self, namelist_obj)
       write(error_unit, '(A)') trim(name) //&
           ' namelist (' // trim(profile_name) // '), already allocated.'
       flush(error_unit)
-      stop
+      stop 1
     else
       call self%bar%insert_item( namelist_obj )
       call self%update_contents(namelist_obj%get_full_name())
@@ -188,7 +188,7 @@ subroutine add_namelist(self, namelist_obj)
       write(error_unit, '(A)') trim(name) //&
           ' namelist (' // trim(profile_name) // '), already allocated.'
       flush(error_unit)
-      stop
+      stop 1
     else
       call self%pot%insert_item( namelist_obj )
       call self%update_contents(namelist_obj%get_full_name())
@@ -199,7 +199,7 @@ subroutine add_namelist(self, namelist_obj)
         ' Undefined namelist type(' // trim(name) //&
         '), for this configuration.'
     flush(error_unit)
-    stop
+    stop 1
 
   end select
 
@@ -281,7 +281,7 @@ function bar_list(self, profile_name) result(bar_nml_obj)
           'bar_nml_type ' //&
           'not found in configuration.'
       flush(error_unit)
-      stop
+      stop 1
     end if
 
     ! Otherwise 'cast' to a bar_namelist_type
@@ -331,7 +331,7 @@ function pot_list(self, profile_name) result(pot_nml_obj)
           'pot_nml_type ' //&
           'not found in configuration.'
       flush(error_unit)
-      stop
+      stop 1
     end if
 
     ! Otherwise 'cast' to a pot_namelist_type

--- a/infrastructure/build/tools/configurator/tests/configuration_loader/content_mod.f90
+++ b/infrastructure/build/tools/configurator/tests/configuration_loader/content_mod.f90
@@ -62,7 +62,7 @@ contains
           'At least one optional argument must ' //&
           'be provided for read_configuration.'
       flush(error_unit)
-      stop
+      stop 1
     end if
 
     local_rank = global_mpi%get_comm_rank()
@@ -178,7 +178,7 @@ contains
           'Arguments "names" and "success_mask" to function' //&
           '"ensure_configuration" are different shapes.'
       flush(error_unit)
-      stop
+      stop 1
     end if
 
     ensure_configuration = .true.
@@ -193,7 +193,7 @@ contains
             'Tried to ensure unrecognised namelist "' //&
             trim(names(i))//'" was loaded.'
         flush(error_unit)
-        stop
+        stop 1
       end select
 
       ensure_configuration = ensure_configuration .and. configuration_found
@@ -263,7 +263,7 @@ contains
                 'Namelist "'//trim(namelists(i)) //&
                 '" can not be read. Too many instances?'
             flush(error_unit)
-            stop
+            stop 1
           end if
 
         case default
@@ -271,7 +271,7 @@ contains
               'Unrecognised namelist "'//trim(namelists(i)) //&
               '" found in file '//trim(filename)//'.'
           flush(error_unit)
-          stop
+          stop 1
         end select
 
       end do ! Namelists

--- a/infrastructure/build/tools/configurator/tests/namelist_feigner/computed_mod.f90
+++ b/infrastructure/build/tools/configurator/tests/namelist_feigner/computed_mod.f90
@@ -47,7 +47,7 @@ contains
 
     if (condition /= 0) then
       write( 6, '("feign_computed_config: ", I0)' ) condition
-      stop
+      stop 1
     end if
 
     write( temporary_unit, '("&computed")' )
@@ -59,7 +59,7 @@ contains
     call read_computed_namelist( temporary_unit, local_rank, scan=.false. )
     call postprocess_computed_namelist()
     close(temporary_unit, iostat=condition )
-    if (condition /= 0) stop temp_close_message
+    if (condition /= 0) error stop temp_close_message
 
   end subroutine feign_computed_config
 

--- a/infrastructure/build/tools/configurator/tests/namelist_feigner/enum_mod.f90
+++ b/infrastructure/build/tools/configurator/tests/namelist_feigner/enum_mod.f90
@@ -47,7 +47,7 @@ contains
 
     if (condition /= 0) then
       write( 6, '("feign_enum_config: ", I0)' ) condition
-      stop
+      stop 1
     end if
 
     write( temporary_unit, '("&enum")' )
@@ -58,7 +58,7 @@ contains
     call read_enum_namelist( temporary_unit, local_rank, scan=.false. )
     call postprocess_enum_namelist()
     close(temporary_unit, iostat=condition )
-    if (condition /= 0) stop temp_close_message
+    if (condition /= 0) error stop temp_close_message
 
   end subroutine feign_enum_config
 

--- a/infrastructure/build/tools/configurator/tests/namelist_feigner/everything_mod.f90
+++ b/infrastructure/build/tools/configurator/tests/namelist_feigner/everything_mod.f90
@@ -64,7 +64,7 @@ contains
 
     if (condition /= 0) then
       write( 6, '("feign_everything_config: ", I0)' ) condition
-      stop
+      stop 1
     end if
 
     write( temporary_unit, '("&everything")' )
@@ -98,7 +98,7 @@ contains
     call read_everything_namelist( temporary_unit, local_rank, scan=.false. )
     call postprocess_everything_namelist()
     close(temporary_unit, iostat=condition )
-    if (condition /= 0) stop temp_close_message
+    if (condition /= 0) error stop temp_close_message
 
   end subroutine feign_everything_config
 

--- a/infrastructure/build/tools/configurator/tests/namelist_feigner/multifile_mod.f90
+++ b/infrastructure/build/tools/configurator/tests/namelist_feigner/multifile_mod.f90
@@ -52,7 +52,7 @@ contains
 
     if (condition /= 0) then
       write( 6, '("feign_first_config: ", I0)' ) condition
-      stop
+      stop 1
     end if
 
     write( temporary_unit, '("&first")' )
@@ -65,7 +65,7 @@ contains
     call read_first_namelist( temporary_unit, local_rank, scan=.false. )
     call postprocess_first_namelist()
     close(temporary_unit, iostat=condition )
-    if (condition /= 0) stop temp_close_message
+    if (condition /= 0) error stop temp_close_message
 
   end subroutine feign_first_config
 
@@ -99,7 +99,7 @@ contains
 
     if (condition /= 0) then
       write( 6, '("feign_second_config: ", I0)' ) condition
-      stop
+      stop 1
     end if
 
     write( temporary_unit, '("&second")' )
@@ -112,7 +112,7 @@ contains
     call read_second_namelist( temporary_unit, local_rank, scan=.false. )
     call postprocess_second_namelist()
     close(temporary_unit, iostat=condition )
-    if (condition /= 0) stop temp_close_message
+    if (condition /= 0) error stop temp_close_message
 
   end subroutine feign_second_config
 

--- a/infrastructure/build/tools/configurator/tests/namelist_feigner/simple_mod.f90
+++ b/infrastructure/build/tools/configurator/tests/namelist_feigner/simple_mod.f90
@@ -51,7 +51,7 @@ contains
 
     if (condition /= 0) then
       write( 6, '("feign_simple_config: ", I0)' ) condition
-      stop
+      stop 1
     end if
 
     write( temporary_unit, '("&simple")' )
@@ -65,7 +65,7 @@ contains
     call read_simple_namelist( temporary_unit, local_rank, scan=.false. )
     call postprocess_simple_namelist()
     close(temporary_unit, iostat=condition )
-    if (condition /= 0) stop temp_close_message
+    if (condition /= 0) error stop temp_close_message
 
   end subroutine feign_simple_config
 


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: 
Code Reviewer: @mike-hobson 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

This PR fixes an issue with error handling in the namelist loader, where the model is stopped in the event of a namelist io error but no error code is given, leading the model to exit with code 0. This causes failing jobs to show as succeeding in rose-stem, obviously undesirable behaviour.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_core - lfric_core-stop-with-code/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [lfric_core-stop-with-code/run1](https://cylchub/services/cylc-review/cycles/edward.hone/?suite=lfric_core-stop-with-code%2Frun1) |
| Suite User | edward.hone |
| Workflow Start | 2026-04-14T11:02:58 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [EdHone/lfric_core@stop-with-code](https://github.com/EdHone/lfric_core/tree/stop-with-code) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@4387949](https://github.com/MetOffice/SimSys_Scripts/tree/4387949) | True |

## Task Information
:white_check_mark: succeeded tasks - 390

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
