### PR TITLE
Extend values doc in modeldb section

### DIFF
--- a/documentation/source/how_to_use_it/lfric_datamodel/modeldb.rst
+++ b/documentation/source/how_to_use_it/lfric_datamodel/modeldb.rst
@@ -129,30 +129,52 @@ of values very powerful. Anything from the object that encapsulates a
 time-stepping algorith to the object that stores all the
 atmosphere-ocean coupling information can be stored in modeldb.
 
-Prior to using the ``values`` collection, it must be have been initialised
-as shown in the code below.
+To initalise a values collection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Prior to using the ``values`` collection, it must be initialised:
+
+.. code-block:: fortran
+
+   call modeldb%values%initialise()
 
 To put a value in
 ^^^^^^^^^^^^^^^^^
+
+This will store a value equal to ``my_value`` in the collection which can be
+accessed with the key string ``my_key``.
 
 .. code-block:: fortran
 
    real(real64) :: my_value
 
    my_value = 7.0_real64
-   call modeldb%values%initialise()
-   call modeldb%values%add_key_value('my_value', my_value)
+   call modeldb%values%add_key_value('my_key', my_value)
 
-Again, this will put a copy of the value into the collection
+To check whether a key exists
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To check whether a key string is already in use, for example, when unsure that a
+required value has been initialised:
+
+.. code-block:: fortran
+
+   logical(l_def)            :: key_exists
+   real(real64), parameter   :: initial_value = 3.45_real64
+
+   key_exists = modeldb%values%key_value_exists('result_value')
+   if ( .not. key_exists) then
+     call modeldb%values%add_key_value('result_value', initial_value)
+   end if
 
 To get a value out
 ^^^^^^^^^^^^^^^^^^
 
 .. code-block:: fortran
 
-   real(real64), pointer :: my_value
+   real(real64), pointer :: result_value
 
-   call modeldb%values%get_value("my_value", my_value)
+   call modeldb%values%get_value('result_value', result_value)
 
 This returns a pointer to the value held in the collection. Any
 subsequent maths performed on what is returned (the pointer) will


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @mike-hobson 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->
A documentation change to add notes on `key_value_exists` to `modeldb`.

For info, adding it now because it will be useful to the new coupled checkpoint branch which currently uses a logical global variable that needs to be initialised to `.false.`; it would be better to add it to modeldb%values, I think.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [ ] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [ ] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
