### PR TITLE
Remove norm from block gcr diagnostics

### DIFF
--- a/components/science/source/solver/sci_iterative_solver_mod.f90
+++ b/components/science/source/solver/sci_iterative_solver_mod.f90
@@ -1510,12 +1510,9 @@ contains
       end do
       init_err = sum(initial_error)
 
-      if (log_at_level( log_level_info )) then
-        ! Only compute the norm if we are going to write it
-        write( log_scratch_space, '(A,E15.8,":",E15.8)' ) &
-             "BLOCK_GCR starting ... ||b|| = ", b%norm(),init_err
-        call log_event(log_scratch_space, LOG_LEVEL_INFO)
-      end if
+      write( log_scratch_space, '(A,E15.8)' ) &
+           "BLOCK_GCR starting ... ||b|| = ", init_err
+      call log_event(log_scratch_space, LOG_LEVEL_INFO)
     end if
 
     ! Use special DDT to avoid CCE bug.


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: <!-- CR id, filled by SSD/CCD (e.g. @octocat) --> @mo-lucy-gordon 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

The block gcr solver computes two versions of the initial error. One (`init_err`) is used to monitor the convergence. The other (coming from `b$norm()`) is only written and isn't needed (since the two versions produce similar results and the `init_err` is the one actually used for convergence checks. This PR removes the duplicate norm saving one global sum per solver call

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [X] Comments have been included that aid understanding and enhance the readability of the code
- [X] My changes generate no new warnings
- [X] All automated checks in the CI pipeline have completed successfully

## Testing

- [X] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - lfric_core - remove_gcr_norm/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [remove_gcr_norm/run1](https://cylchub/services/cylc-review/cycles/thomas.melvin/?suite=remove_gcr_norm%2Frun1) |
| Suite User | thomas.melvin |
| Workflow Start | 2026-05-07T15:13:10 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [thomasmelvin/lfric_core@remove_gcr_norm](https://github.com/thomasmelvin/lfric_core/tree/remove_gcr_norm) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 402


## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
