### PR TITLE
Enable lfric_core rose-stem suites to use the use EX1b Genoa nodes

### DIFF
--- a/rose-stem/site/meto/common/suite_config_ex1a.cylc
+++ b/rose-stem/site/meto/common/suite_config_ex1a.cylc
@@ -42,7 +42,7 @@
         [[[environment]]]
             BUILD_ROOT = ${TMPDIR}
             HYPERTHREADS    = 1
-            CORES_PER_NODE  = 128
+            CORES_PER_NODE  = {{site_vars.node_cores}}
             NUMA_REGIONS_PER_NODE = 2
 
     [[EX1A_BUILD]]

--- a/rose-stem/site/meto/macros/macros_ex1a.cylc
+++ b/rose-stem/site/meto/macros/macros_ex1a.cylc
@@ -5,7 +5,11 @@
 {# ########################################################################### #}
 {% do LOG.debug("Entered site/meto/macros/macros_ex1a.cylc") %}
 
-{% set ex1a_cores_per_node = 128 %}
+{% if site_vars.node_type == "genoa" %}
+    {% set ex1a_cores_per_node = 192 %}
+{% else %}
+    {% set ex1a_cores_per_node = 128 %}
+{% endif %}
 {% set ex1a_socket_per_node = 2 %}
 
 {% macro normal_queue(mpi_ranks,
@@ -67,7 +71,7 @@
             -l select={{ lfric_nodes +
                          ocean_nodes|int +
                          river_nodes|int +
-                         xios_nodes|int }}
+                         xios_nodes|int }}:coretype={{site_vars.node_type}}:mem={{site_vars.node_mem}}GB
 {% endmacro %}
 
 

--- a/rose-stem/site/meto/variables.cylc
+++ b/rose-stem/site/meto/variables.cylc
@@ -75,6 +75,17 @@
 {% endif %}
 {% do LOG.info("Host EX: " + site_vars.host_ex) %}
 
+{# Set node type target #}
+{% if USE_GENOA is defined and USE_GENOA %}
+    {% do site_vars.update({"node_type": "genoa"}) %}
+    {% do site_vars.update({"node_cores": 192 }) %}
+    {% do site_vars.update({"node_mem": 720}) %}
+{% else %}
+    {% do site_vars.update({"node_type": "milan"}) %}
+    {% do site_vars.update({"node_cores": 128 }) %}
+    {% do site_vars.update({"node_mem": 238}) %}
+{% endif %}
+
 {% include "site/meto/common/default_directives.cylc" %}
 
 {% do LOG.debug("Finished in site/meto/variables.cylc") %}


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer:
Code Reviewer: @james-bruten-mo 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

With the opening of the user acceptance testing for the Gen1b nodes on the Cray EX machines, some switches were set up within lfric_apps (MetOffice/lfric_apps#89, MetOffice/lfric_apps#410) which enabled users to schedule their tests on these nodes. This PR implements the same switches within lfric_core.

To run the tests, simply add the `-S USE_GENOA=true` directive to your suite command.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_core - lfric_core-enable-genoa/run2 (Milan nodes)

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [lfric_core-enable-genoa/run2](https://cylchub/services/cylc-review/cycles/edward.hone/?suite=lfric_core-enable-genoa%2Frun2) |
| Suite User | edward.hone |
| Workflow Start | 2026-05-12T09:55:51 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [EdHone/lfric_core@enable-genoa](https://github.com/EdHone/lfric_core/tree/enable-genoa) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 402

# Test Suite Results - lfric_core - lfric_core-enable-genoa/run1 (Genoa nodes)

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [lfric_core-enable-genoa/run1](https://cylchub/services/cylc-review/cycles/edward.hone/?suite=lfric_core-enable-genoa%2Frun1) |
| Suite User | edward.hone |
| Workflow Start | 2026-05-12T09:55:19 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [EdHone/lfric_core@enable-genoa](https://github.com/EdHone/lfric_core/tree/enable-genoa) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 402


## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
