### PR TITLE
Fix parallel implementation of temporal reading

### DIFF
--- a/components/lfric-xios/source/lfric_xios_temporal_mod.x90
+++ b/components/lfric-xios/source/lfric_xios_temporal_mod.x90
@@ -289,7 +289,7 @@ contains
                                               output_freq=timestep_duration, &
                                               mode="read",                   &
                                               type="one_file",               &
-                                              record_offset=record_offset,  &
+                                              record_offset=record_offset,   &
                                               time_counter_name="time",      &
                                               enabled=.true. )
 
@@ -299,7 +299,7 @@ contains
       ! Add fields to initial file definition
       init_fields_id = trim(file_id)//init_suffix//"_field_group"
       call xios_add_child(initial_read_file, init_fieldgroup, trim(init_fields_id))
-      call xios_set_attr(init_fieldgroup, operation="once", read_access=.true.)
+      call xios_set_attr(init_fieldgroup, operation="instant", read_access=.true.)
       do i = 1, n_fields
         init_field_ptr => self%fields(f,i)
         self%init_fields(f,i) = lfric_xios_field_type( init_field_ptr, &

--- a/components/lfric-xios/source/lfric_xios_temporal_mod.x90
+++ b/components/lfric-xios/source/lfric_xios_temporal_mod.x90
@@ -286,12 +286,12 @@ contains
                             trim(file_id)//init_suffix )
 
       call xios_set_attr( initial_read_file, name=trim(adjustl(file_path)), &
-                                              output_freq=timestep_duration, &
-                                              mode="read",                   &
-                                              type="one_file",               &
-                                              record_offset=record_offset,   &
-                                              time_counter_name="time",      &
-                                              enabled=.true. )
+                                             output_freq=timestep_duration, &
+                                             mode="read",                   &
+                                             type="one_file",               &
+                                             record_offset=record_offset,   &
+                                             time_counter_name="time",      &
+                                             enabled=.true. )
 
       ! Move on record offset for next read
       record_offset = record_offset + 1
@@ -299,7 +299,7 @@ contains
       ! Add fields to initial file definition
       init_fields_id = trim(file_id)//init_suffix//"_field_group"
       call xios_add_child(initial_read_file, init_fieldgroup, trim(init_fields_id))
-      call xios_set_attr(init_fieldgroup, operation="instant", read_access=.true.)
+      call xios_set_attr(init_fieldgroup, operation="once", read_access=.true.)
       do i = 1, n_fields
         init_field_ptr => self%fields(f,i)
         self%init_fields(f,i) = lfric_xios_field_type( init_field_ptr, &

--- a/components/lfric-xios/source/lfric_xios_utils_mod.f90
+++ b/components/lfric-xios/source/lfric_xios_utils_mod.f90
@@ -172,6 +172,9 @@ module lfric_xios_utils_mod
     type(lfric_ncdf_dims_type)  :: time_dim
     type(lfric_ncdf_field_type) :: time_var
 
+    call log_event( "Reading time data from file ["//trim(file_path)//"]", &
+                    LOG_LEVEL_TRACE )
+
     if (global_mpi%get_comm_rank() == 0) then
       file_ncdf = lfric_ncdf_file_type( trim(file_path)//".nc", &
                                         open_mode=FILE_OP_OPEN, &
@@ -194,7 +197,6 @@ module lfric_xios_utils_mod
       time_dim = lfric_ncdf_dims_type(trim(dim_id), file_ncdf)
       n_t = time_dim%get_size()
       allocate( input_data( n_t ) )
-      allocate( time_data( n_t ) )
 
       ! Read the time data from the ancil file
       time_var = lfric_ncdf_field_type(trim(var_id), file_ncdf)
@@ -228,6 +230,7 @@ module lfric_xios_utils_mod
     call global_mpi%broadcast(input_data, n_t_buf(1), 0)
     call global_mpi%broadcast(time_meta_buf, size(time_meta_buf, 1)*str_def, 0)
 
+    allocate(time_data(n_t))
     ref_date_str = time_meta_buf(1)
     time_units = time_meta_buf(2)
     ref_date = parse_date_as_xios(trim(adjustl(ref_date_str)))

--- a/components/lfric-xios/source/lfric_xios_utils_mod.f90
+++ b/components/lfric-xios/source/lfric_xios_utils_mod.f90
@@ -230,7 +230,7 @@ module lfric_xios_utils_mod
     call global_mpi%broadcast(input_data, n_t_buf(1), 0)
     call global_mpi%broadcast(time_meta_buf, size(time_meta_buf, 1)*str_def, 0)
 
-    allocate(time_data(n_t))
+    allocate(time_data(n_t_buf(1)))
     ref_date_str = time_meta_buf(1)
     time_units = time_meta_buf(2)
     ref_date = parse_date_as_xios(trim(adjustl(ref_date_str)))

--- a/rose-stem/app/io_demo/opt/rose-app-C48.conf
+++ b/rose-stem/app/io_demo/opt/rose-app-C48.conf
@@ -1,0 +1,10 @@
+[file:mesh_C48.nc]
+mode=auto
+source=$MESH_DIR/mesh_C48.nc
+
+[namelist:base_mesh]
+file_prefix='mesh_C48'
+geometry='spherical'
+
+[namelist:partitioning]
+partitioner='cubedsphere'

--- a/rose-stem/site/common/io_demo/tasks_io_demo.cylc
+++ b/rose-stem/site/common/io_demo/tasks_io_demo.cylc
@@ -48,6 +48,32 @@
         "tsteps": 90,
     }) %}
 
+
+{% elif task_ns.conf_name == "temporal_reading-C48" %}
+
+    {% do task_dict.update({
+        "opt_confs": ["temporal_reading"],
+        "resolution": "C48",
+        "tsteps": 90,
+        "kgo_checks": [],
+        "mpi_parts": 24,
+    }) %}
+
+
+{% elif task_ns.conf_name == "temporal_reading-C48-servers" %}
+
+    {% do task_dict.update({
+        "opt_confs": ["temporal_reading"],
+        "resolution": "C48",
+        "tsteps": 90,
+        "kgo_checks": [],
+        "mpi_parts": 24,
+        "mpi_parts_xios": 1,
+        "xios_nodes": 1,
+        "xios_server_mode": true,
+        "xios_server_ranks": 1,
+    }) %}
+
 {% elif task_ns.conf_name == "benchmark-C24" %}
 
     {% do task_dict.update({

--- a/rose-stem/site/common/io_demo/tasks_io_demo.cylc
+++ b/rose-stem/site/common/io_demo/tasks_io_demo.cylc
@@ -60,7 +60,7 @@
     }) %}
 
 
-{% elif task_ns.conf_name == "temporal_reading-C48-servers" %}
+{% elif task_ns.conf_name == "temporal_reading-C48-server" %}
 
     {% do task_dict.update({
         "opt_confs": ["temporal_reading"],

--- a/rose-stem/site/meto/groups/group_io_demo.cylc
+++ b/rose-stem/site/meto/groups/group_io_demo.cylc
@@ -19,6 +19,7 @@
         "io_demo_multifile-C24_azspice_gnu_fast-debug-32bit",
         "io_demo_temporal_reading-C12_azspice_gnu_fast-debug-64bit",
         "io_demo_temporal_reading-C12_azspice_gnu_fast-debug-32bit",
+        "io_demo_temporal_reading-C48_azspice_gnu_fast-debug-32bit",
         "io_demo_benchmark-C24_azspice_gnu_fast-debug-64bit",
         "io_demo_benchmark-C24_azspice_gnu_fast-debug-32bit",
         "io_demo_azspice_unit_tests",
@@ -57,6 +58,8 @@
         "io_demo_temporal_reading-C12_ex1a_cce_fast-debug-32bit",
         "io_demo_temporal_reading-C12_ex1a_gnu_fast-debug-64bit",
         "io_demo_temporal_reading-C12_ex1a_gnu_fast-debug-32bit",
+        "io_demo_temporal_reading-C48_ex1a_cce_fast-debug-32bit",
+        "io_demo_temporal_reading-C48_ex1a_gnu_fast-debug-64bit",
         "io_demo_benchmark-C24_ex1a_cce_fast-debug-32bit",
         "io_demo_benchmark-C24_ex1a_gnu_fast-debug-32bit",
         "io_demo_benchmark-C24_ex1a_gnu_fast-debug-64bit",
@@ -65,6 +68,10 @@
     "io_demo_ex1a_benchmark": [
         "io_demo_benchmark-nwp-C224_ex1a_cce_fast-debug-32bit",
         "io_demo_benchmark-nwp-C224_ex1a_gnu_fast-debug-32bit",
+    ],
+    "io_demo_ex1a_servers": [
+        "io_demo_temporal_reading-C48-server_ex1a_cce_fast-debug-32bit",
+        "io_demo_temporal_reading-C48-server_ex1a_gnu_fast-debug-64bit",
     ],
     "io_demo_ex1a": [
         "io_demo_ex1a_developer"


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @MatthewHambley 
<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

On further investigation the temporal reading implementation had some issues when running in parallel, namely that the reading time data was not correctly implemented. This has been fixed in this PR and new tests added which test this functionality in parallel.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [x] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_core - lfric_core-fix-temporal-parallel/run3

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [lfric_core-fix-temporal-parallel/run3](https://cylchub/services/cylc-review/cycles/edward.hone/?suite=lfric_core-fix-temporal-parallel%2Frun3) |
| Suite User | edward.hone |
| Workflow Start | 2026-06-24T12:07:27 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [EdHone/lfric_core@fix-temporal-parallel](https://github.com/EdHone/lfric_core/tree/fix-temporal-parallel) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 427

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
