### PR TITLE
Set mpi-io metadata read for file for read_access scalability

### DIFF
--- a/components/lfric-xios/source/lfric_xios_context_mod.f90
+++ b/components/lfric-xios/source/lfric_xios_context_mod.f90
@@ -51,6 +51,7 @@ module lfric_xios_context_mod
     type(xios_context)     :: handle
     type(linked_list_type) :: filelist
     integer(i_def)         :: context_clock_step = 1_i_def
+    type(lfric_comm_type)  :: communicator
 
     logical :: uses_timer = .false.
     logical :: xios_context_initialised = .false.
@@ -147,6 +148,8 @@ contains
       zero_start = .false.
     end if
 
+    this%communicator = communicator
+
     call xios_context_initialize( this%get_context_name(), &
                                   communicator%get_comm_mpi_val() )
     call xios_get_handle( this%get_context_name(), this%handle )
@@ -191,6 +194,8 @@ contains
     ! can be defined after this point
     if ( LPROF ) call start_timing(timing_id, 'xios.close_context_definition')
     call log_event('XIOS context definition closing', log_level_debug)
+    ! Set an MPI barrier to support MPI-IO metadata interaction synchronisation.
+    call this%communicator%barrier_mpi()
     call xios_close_context_definition()
     if ( LPROF ) call stop_timing(timing_id, 'xios.close_context_definition')
     call log_event('XIOS context definition closed', log_level_debug)

--- a/components/lfric-xios/source/lfric_xios_file_mod.f90
+++ b/components/lfric-xios/source/lfric_xios_file_mod.f90
@@ -427,10 +427,11 @@ subroutine register_with_context(self)
     call xios_add_child(self%handle, file_fields, self%field_group_id)
   end if
 
-  ! Set up read_access attribute for fields in file
-   if (self%mode_is_read()) then
-     call xios_set_attr(file_fields, read_access=.true.)
-   end if
+  ! Set mpi-io metadata read for file & read_access attribute for fields in file
+  if (self%mode_is_read()) then
+    call xios_set_attr(self%handle, read_metadata_par=.true.)
+    call xios_set_attr(file_fields, read_access=.true.)
+ end if
 
   ! Set up fields in file
   if (allocated(self%fields)) then

--- a/infrastructure/source/utilities/lfric_mpi_mod.F90
+++ b/infrastructure/source/utilities/lfric_mpi_mod.F90
@@ -23,7 +23,7 @@ module lfric_mpi_mod
                  mpi_character,                                         &
                  mpi_init, mpi_finalize,                                &
                  mpi_comm_dup, mpi_comm_free,                           &
-                 mpi_comm_size, mpi_comm_rank
+                 mpi_comm_size, mpi_comm_rank, mpi_barrier
 #else
   use mpi_f08, only: mpi_comm, mpi_datatype, mpi_comm_world,                &
                      mpi_sum, mpi_min, mpi_max, mpi_success,                &
@@ -32,7 +32,7 @@ module lfric_mpi_mod
                      mpi_character,                                         &
                      mpi_init, mpi_finalize,                                &
                      mpi_comm_dup, mpi_comm_free,                           &
-                     mpi_comm_size, mpi_comm_rank
+                     mpi_comm_size, mpi_comm_rank, mpi_barrier
 #endif
 ! The above use statement should include mpi_bcast, mpi_allreduce and
 ! mpi_allgather, but an apparent bug in Cray mpich causes a failure if
@@ -150,6 +150,7 @@ module lfric_mpi_mod
   contains
     procedure, public :: get_comm_mpi_val
     procedure, public :: set_comm_mpi_val
+    procedure, public :: barrier_mpi
   end type
 
 #ifdef NO_MPI
@@ -1525,6 +1526,23 @@ contains
 #endif
 #endif
   end subroutine set_comm_mpi_val
+
+  !> Call an MPI Barrier, synchronising ranks in the communicator.
+  subroutine barrier_mpi(self)
+    implicit none
+    class(lfric_comm_type), intent(in)  :: self
+    integer :: ierr
+
+#ifdef NO_MPI
+    ! null operation, barrier is non-existant
+    ierr = 0
+#else
+    call mpi_barrier(self%comm, ierr)
+    if (ierr /= mpi_success) then
+      call log_event('Unable to progress through MPI barrier', LOG_LEVEL_ERROR )
+    end if
+#endif
+  end subroutine barrier_mpi
 
   !> Returns the integer datatype
   !>


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @harry-shepherd 
Code Reviewer: @stevemullerworth 

<!-- To be completed by the developer -->

For scalability for large rank counts of simulation ranks then it is essential that XIOS is instructed to avoid using serial netCDF calls to call `nc_open` on HDF5 encoded netCDF files.

XIOS uses MPI-IO collective calls for data interactions by default (good for scale) and provides an opt-in switch to use MPI-IO for metadata reads `read_metadata_par` [read_metadata_par](https://ipsl.pages.in2p3.fr/projets/xios-projects/xios/XIOS_reference_guide/#read_metadata_par-optional-bool) 

But, this operates on a file object, so needs to be managed many times, or deep within the LFRic interface.

This PR proposes a full opt in of this for all uses.
Preliminary analyses show that this is not problematic at small scales and very useful at large scales.

More nuanced implementations could be explored, but do not yet seem justified, compared to this simple full opt in

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [x] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - lfric_core - read_metadata_par_lfric_xios/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [read_metadata_par_lfric_xios/run1](https://cylchub/services/cylc-review/cycles/mark.hedley/?suite=read_metadata_par_lfric_xios%2Frun1) |
| Suite User | mark.hedley |
| Workflow Start | 2026-06-29T12:49:46 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [mo-marqh/lfric_core@read_metadata_par_lfric_xios](https://github.com/mo-marqh/lfric_core/tree/read_metadata_par_lfric_xios) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 427


# Test Suite Results - lfric_apps - io_trace_intercept-nc_open_par/run5

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [io_trace_intercept-nc_open_par/run5](https://cylchub/services/cylc-review/cycles/mark.hedley/?suite=io_trace_intercept-nc_open_par%2Frun5) |
| Suite User | mark.hedley |
| Workflow Start | 2026-06-29T08:20:19 |
| Groups Run | lfric_atm_nwp_gal9_oper-C224_MG_ex1a_cce_production-32bit |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.2](https://github.com/MetOffice/casim/tree/2026.03.2) | True |
| jules | [MetOffice/jules@1ea67b4](https://github.com/MetOffice/jules/tree/1ea67b4) | True |
| lfric_apps | [mo-marqh/lfric_apps@io_trace_intercept-nc_open_par](https://github.com/mo-marqh/lfric_apps/tree/io_trace_intercept-nc_open_par) | False |
| lfric_core | [mo-marqh/lfric_core@metadata-mpiio-read](https://github.com/mo-marqh/lfric_core/tree/metadata-mpiio-read) | False |
| moci | [MetOffice/moci@2026.03.2](https://github.com/MetOffice/moci/tree/2026.03.2) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@3e2998b](https://github.com/MetOffice/SimSys_Scripts/tree/3e2998b) | True |
| socrates | [MetOffice/socrates@2026.03.2](https://github.com/MetOffice/socrates/tree/2026.03.2) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.03.2](https://github.com/MetOffice/socrates-spectral/tree/2026.03.2) | True |
| ukca | [MetOffice/ukca@1cdb9c2](https://github.com/MetOffice/ukca/tree/1cdb9c2) | True |

## Task Information
:white_check_mark: succeeded tasks - 8

### Timer Comparison

|           Routine            |   Baseline times    |   Branch times     |
| :--- | :--- | :--- |
|                       lfric_atm |               175.30 ≤ 175.31 ≤175.31 |                161.58 ≤   161.59 ≤         161.60 |
|        gungho_driver.initialise |                27.58 ≤ 27.66 ≤  27.67 |                 26.26 ≤                26.35 ≤  26.37 |
|       gungho_driver.load_meshes |                 0.92 ≤   0.98 ≤   1.00 |                  2.19 ≤                 2.23 ≤     2.25 |
|                      field.read |                16.76 ≤   16.82 ≤  16.89 |                 15.00 ≤                15.12 ≤   15.19 |
|                 gungho_timestep |               106.29 ≤ 107.37 ≤   107.71 |               101.07 ≤              102.15 ≤       102.42 |
|          gungho_driver.finalise |                28.24 ≤   28.62 ≤    29.00 |                18.32 ≤     18.40 ≤   18.47 |


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
