### PR TITLE
Including the changes to use F10.6 precision for domain_centre

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,3 +34,5 @@
 | ukmo-juan-castillo  | Juan M. Castillo    | Met Office            | 2026-03-24 |
 | mcdalvi          | Mohit Dalvi            | Met Office            | 2026-06-19 |
 | cjohnson-pi      | Christine Johnson      | Met Office            | 2026-06-29 |
+| mo-claudiosanchez | Claudio Sanchez      | Met Office            | 2026-07-23 |
+

--- a/mesh_tools/source/support/gen_planar_mod.F90
+++ b/mesh_tools/source/support/gen_planar_mod.F90
@@ -404,8 +404,8 @@ function gen_planar_constructor( reference_element,          &
   write(rchar_y, '(F10.2)') domain_size(2)
   write(domain_size_str, '(A)') '['//trim(adjustl(rchar_x))// &
                                 ','//trim(adjustl(rchar_y))//']'
-  write(rchar_x, '(F10.2)') domain_centre(1)
-  write(rchar_y, '(F10.2)') domain_centre(2)
+  write(rchar_x, '(F10.6)') domain_centre(1)
+  write(rchar_y, '(F10.6)') domain_centre(2)
   write(domain_centre_str, '(A)') '['//trim(adjustl(rchar_x))// &
                                   ','//trim(adjustl(rchar_y))//']'
 

--- a/mesh_tools/unit-test/gen_planar_mod_test_cartesian.pf
+++ b/mesh_tools/unit-test/gen_planar_mod_test_cartesian.pf
@@ -1316,8 +1316,8 @@ contains
                                   trim(adjustl(x_str))//','// &
                                   trim(adjustl(y_str))//']'
 
-    write(x_str, '(F10.2)') context%domain_centre(1)
-    write(y_str, '(F10.2)') context%domain_centre(2)
+    write(x_str, '(F10.6)') context%domain_centre(1)
+    write(y_str, '(F10.6)') context%domain_centre(2)
     write(domain_centre_str, '(A)') ';domain_centre=['//        &
                                     trim(adjustl(x_str))//','// &
                                     trim(adjustl(y_str))//']'

--- a/mesh_tools/unit-test/gen_planar_mod_test_spherical.pf
+++ b/mesh_tools/unit-test/gen_planar_mod_test_spherical.pf
@@ -363,8 +363,8 @@ contains
                                   trim(adjustl(x_str))//','// &
                                   trim(adjustl(y_str))//']'
 
-    write(x_str, '(F10.2)') context%domain_centre(1)
-    write(y_str, '(F10.2)') context%domain_centre(2)
+    write(x_str, '(F10.6)') context%domain_centre(1)
+    write(y_str, '(F10.6)') context%domain_centre(2)
     write(domain_centre_str, '(A)') ';domain_centre=['//        &
                                     trim(adjustl(x_str))//','// &
                                     trim(adjustl(y_str))//']'


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @mo-rickywong 
Code Reviewer: @mo-marqh 

This PR is made to write the domain_centre variable in the mesh's _"constructor_inputs"_ with higher truncation (from 2 to 6 decimals). 

See issue #433 

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [x] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

_The cylc-review of the rose stem testing is [rose_stem_lfric_core/run1](https://cylchub/services/cylc-review/taskjobs/claudio.sanchez/?suite=rose_stem_lfric_core%2Frun1). All **check_mesh_tools** for LAMs fails as the branch outputs domain_centre with more zeroes. E.g. 
```
Result : /home/users/claudio.sanchez/cylc-run/rose_stem_lfric_core/run1/share/output/mesh_tools/mesh_tools_equator-band_azspice_gnu_fast-debug-64bit/mesh_equator-band.nc
KGO : /home/users/claudio.sanchez/cylc-run/rose_stem_lfric_core/run1/share/source/lfric_core/rose-stem/site/meto/kgos/mesh_tools/azspice/mesh_equator-band.gnu.kgo.nc
````


### trac.log

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [rose_stem_lfric_core/run1](https://cylchub/services/cylc-review/cycles/claudio.sanchez/?suite=rose_stem_lfric_core%2Frun1) |
| Suite User | claudio.sanchez |
| Workflow Start | 2026-07-23T09:03:13 |
| Groups Run | mesh_tools_developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [mo-claudiosanchez/lfric_core@mesh_domain_centre_10Fp6](https://github.com/mo-claudiosanchez/lfric_core/tree/mesh_domain_centre_10Fp6) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
<details>
<summary>:x: failed tasks - 60</summary>

| Task | State |
| :--- | :--- |
| check_mesh_tools_equator-band_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_equator-band_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_equator-band_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_equator_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_equator_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_equator_ex1a_cce_full-debug-64bit | failed |
| check_mesh_tools_falklands_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_falklands_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_falklands_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_lam_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_lam_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_lam_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_london-model_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_london-model_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_london-model_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_nzlam4_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_nzlam4_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_nzlam4_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-bi-periodic_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-bi-periodic_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-bi-periodic_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-lbc_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-lbc_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-lbc_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-maps_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-maps_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-maps_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-non-periodic_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-non-periodic_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-non-periodic_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-op-lam_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-op-lam_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-op-lam_ex1a_cce_full-debug-64bit | failed |
| check_mesh_tools_planar-stretch-centres_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-stretch-centres_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-stretch-centres_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-stretch-nodes_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-stretch-nodes_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-stretch-nodes_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-stretch-points_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-stretch-points_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-stretch-points_ex1a_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-trench-x_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-trench-x_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-trench-x_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_planar-trench-y_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_planar-trench-y_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_planar-trench-y_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_polar_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_polar_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_polar_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_uk_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_uk_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_uk_ex1a_cce_fast-debug-64bit | failed |
| check_mesh_tools_var-poly-seuk_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_var-poly-seuk_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_var-poly-seuk_ex1a_gnu_fast-debug-64bit | failed |
| check_mesh_tools_var-seuk_azspice_gnu_fast-debug-64bit | failed |
| check_mesh_tools_var-seuk_azspice_gnu_full-debug-64bit | failed |
| check_mesh_tools_var-seuk_ex1a_gnu_fast-debug-64bit | failed |
</details>
:white_check_mark: succeeded tasks - 144
<details>
<summary>:hourglass: waiting tasks - 2</summary>

| Task | State |
| :--- | :--- |
| housekeep_azspice | waiting |
| housekeep_ex1a | waiting |
</details>

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
