### PR TITLE
Load mesh limit open calls per rank

### DIFF
--- a/components/driver/source/driver_mesh_mod.f90
+++ b/components/driver/source/driver_mesh_mod.f90
@@ -56,6 +56,9 @@ module driver_mesh_mod
   use finite_element_config_mod, only: cellshape_quadrilateral
   use base_mesh_config_mod,      only: geometry_spherical, &
                                        topology_fully_periodic
+    use ugrid_2d_mod,   only: ugrid_2d_type
+    use ugrid_file_mod, only: ugrid_file_type
+    use ncdf_quad_mod,  only: ncdf_quad_type
 
   implicit none
 
@@ -146,6 +149,9 @@ subroutine init_mesh( config,                  &
   character(str_def) :: fmt_str, number_str
 
   integer(i_def) :: i, n_digit
+  type(ugrid_2d_type) :: ugrid_2d
+
+  class(ugrid_file_type), allocatable :: file_handler
 
   !============================================================================
   ! Extract configuration variables
@@ -212,7 +218,6 @@ subroutine init_mesh( config,                  &
     allocate(names, source=mesh_names)
   end if
 
-
   !===========================================================================
   ! Create local mesh objects:
   !   Two code pathes presented, either:
@@ -245,6 +250,18 @@ subroutine init_mesh( config,                  &
     write(number_str, fmt_str) local_rank
     write(input_mesh_file, '(A, "_", A, "-", I0, ".nc")') &
         trim(file_prefix), trim(number_str), total_ranks
+    !====
+    ! Open mesh file
+    ! Once!
+    !====
+    write(log_scratch_space, '(A)')                   &
+                    'opening file: "'// trim(input_mesh_file) // &
+                    '" with MPI-IO for shared access'
+    call log_event(log_scratch_space, LOG_LEVEL_debug)
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(input_mesh_file))
 
     call log_event( 'Using pre-partitioned mesh file:', log_level_debug )
     call log_event( '   '//trim(input_mesh_file), log_level_debug )
@@ -256,7 +273,7 @@ subroutine init_mesh( config,                  &
     !===========================================================
     ! Each partitioned mesh file will contain meshes of the
     ! same name as all other partitions.
-    call load_local_mesh( input_mesh_file, mesh_names )
+    call load_local_mesh( input_mesh_file, mesh_names, ugrid_2d )
 
     ! Apply configuration related checks to ensure that these
     ! meshes are suitable for the supplied application
@@ -273,7 +290,7 @@ subroutine init_mesh( config,                  &
     ! need to be loaded after the relevant local meshes have
     ! been loaded.
     tmp_mesh_names = local_mesh_collection%get_mesh_names()
-    call load_local_mesh_maps( input_mesh_file, tmp_mesh_names )
+    call load_local_mesh_maps( input_mesh_file, tmp_mesh_names, ugrid_2d )
     if (allocated(tmp_mesh_names)) deallocate(tmp_mesh_names)
 
   else
@@ -298,6 +315,19 @@ subroutine init_mesh( config,                  &
     end if
     write(input_mesh_file,'(A)') trim(file_prefix) // '.nc'
 
+    !====
+    ! Open mesh file
+    ! Once!
+    !====
+    write(log_scratch_space, '(A)')                   &
+                    'opening file: "'// trim(input_mesh_file) // &
+                    '" with MPI-IO for shared access'
+    call log_event(log_scratch_space, LOG_LEVEL_debug)
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(input_mesh_file))
+
     ! 2.2a Set constants that will control partitioning.
     !===========================================================
     call get_partition_parameters( config%partitioning, mesh_selection, &
@@ -306,7 +336,7 @@ subroutine init_mesh( config,                  &
 
     ! 2.2b Read in all global meshes from input file
     !===========================================================
-    call load_global_mesh( input_mesh_file, mesh_names )
+    call load_global_mesh( input_mesh_file, mesh_names, ugrid_2d )
 
     ! 2.2c Apply configuration related checks to ensure that these
     !      meshes are suitable for the supplied application
@@ -328,12 +358,16 @@ subroutine init_mesh( config,                  &
     ! 2.2f Read in the global intergrid mesh mappings,
     !      then create the associated local mesh maps
     !===========================================================
-    call create_local_mesh_maps( input_mesh_file )
+    call create_local_mesh_maps( input_mesh_file, ugrid_2d )
 
     ! Clear the global mesh
     call global_mesh_collection%clear()
 
   end if  ! prepartitioned
+
+  call ugrid_2d%file_handler%file_close()
+  if (allocated(file_handler)) deallocate( file_handler )
+
 
   !============================================================================
   ! 3.0 Extrude the specified meshes from local mesh objects into

--- a/components/driver/source/driver_mesh_mod.f90
+++ b/components/driver/source/driver_mesh_mod.f90
@@ -261,7 +261,7 @@ subroutine init_mesh( config,                  &
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(input_mesh_file))
+    call ugrid_2d%file_handler_open(trim(input_mesh_file))
 
     call log_event( 'Using pre-partitioned mesh file:', log_level_debug )
     call log_event( '   '//trim(input_mesh_file), log_level_debug )
@@ -326,7 +326,7 @@ subroutine init_mesh( config,                  &
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(input_mesh_file))
+    call ugrid_2d%file_handler_open(trim(input_mesh_file))
 
     ! 2.2a Set constants that will control partitioning.
     !===========================================================
@@ -365,7 +365,7 @@ subroutine init_mesh( config,                  &
 
   end if  ! prepartitioned
 
-  call ugrid_2d%file_handler%file_close()
+  call ugrid_2d%file_handler_close()
   if (allocated(file_handler)) deallocate( file_handler )
 
 

--- a/components/driver/source/driver_mesh_mod.f90
+++ b/components/driver/source/driver_mesh_mod.f90
@@ -56,9 +56,11 @@ module driver_mesh_mod
   use finite_element_config_mod, only: cellshape_quadrilateral
   use base_mesh_config_mod,      only: geometry_spherical, &
                                        topology_fully_periodic
-    use ugrid_2d_mod,   only: ugrid_2d_type
-    use ugrid_file_mod, only: ugrid_file_type
-    use ncdf_quad_mod,  only: ncdf_quad_type
+  use timing_mod,                only: start_timing, stop_timing, &
+                                       tik, LPROF
+  use ugrid_2d_mod,              only: ugrid_2d_type
+  use ugrid_file_mod,            only: ugrid_file_type
+  use ncdf_quad_mod,             only: ncdf_quad_type
 
   implicit none
 
@@ -149,10 +151,12 @@ subroutine init_mesh( config,                  &
   character(str_def) :: fmt_str, number_str
 
   integer(i_def) :: i, n_digit
+  integer(tik) :: timing_id
   type(ugrid_2d_type) :: ugrid_2d
 
   class(ugrid_file_type), allocatable :: file_handler
 
+  if ( LPROF ) call start_timing(timing_id, 'driver.init_mesh')
   !============================================================================
   ! Extract configuration variables
   !============================================================================
@@ -384,6 +388,7 @@ subroutine init_mesh( config,                  &
   call assign_mesh_maps(mesh_names)
 
   deallocate(stencil_depths)
+  if ( LPROF ) call stop_timing(timing_id, 'driver.init_mesh')
 
 end subroutine init_mesh
 

--- a/components/driver/source/mesh/load_global_mesh_mod.f90
+++ b/components/driver/source/mesh/load_global_mesh_mod.f90
@@ -46,7 +46,7 @@ subroutine load_global_mesh_multiple( input_mesh_file, &
   character(str_def),          intent(in) :: mesh_names(:)
 
   integer(i_def) :: i
-    type(ugrid_2d_type), intent(inout) :: ugrid_2d
+  type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   do i=1, size(mesh_names)
     call load_global_mesh_single( input_mesh_file, &
@@ -73,7 +73,7 @@ subroutine load_global_mesh_single( input_mesh_file, &
   type(ugrid_mesh_data_type) :: ugrid_mesh_data
   type(global_mesh_type)     :: global_mesh
 
-    type(ugrid_2d_type), intent(inout) :: ugrid_2d
+  type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   if (.not. global_mesh_collection%check_for(mesh_name)) then
 

--- a/components/driver/source/mesh/load_global_mesh_mod.f90
+++ b/components/driver/source/mesh/load_global_mesh_mod.f90
@@ -16,6 +16,7 @@ module load_global_mesh_mod
 
 
   use global_mesh_collection_mod, only: global_mesh_collection
+  use ugrid_2d_mod,   only: ugrid_2d_type
 
   implicit none
 
@@ -37,7 +38,7 @@ contains
 !> @param[in] mesh_names       The names of the global meshes to load
 !>                             from the <input_mesh_file>.
 subroutine load_global_mesh_multiple( input_mesh_file, &
-                                      mesh_names )
+                                      mesh_names, ugrid_2d )
 
   implicit none
 
@@ -45,10 +46,11 @@ subroutine load_global_mesh_multiple( input_mesh_file, &
   character(str_def),          intent(in) :: mesh_names(:)
 
   integer(i_def) :: i
+    type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   do i=1, size(mesh_names)
     call load_global_mesh_single( input_mesh_file, &
-                                  mesh_names(i) )
+                                  mesh_names(i), ugrid_2d )
   end do
 
 end subroutine load_global_mesh_multiple
@@ -61,7 +63,7 @@ end subroutine load_global_mesh_multiple
 !> @param[in] mesh_name        The name of the global mesh to load
 !>                             from the <input_mesh_file>.
 subroutine load_global_mesh_single( input_mesh_file, &
-                                    mesh_name )
+                                    mesh_name, ugrid_2d )
 
   implicit none
 
@@ -71,6 +73,8 @@ subroutine load_global_mesh_single( input_mesh_file, &
   type(ugrid_mesh_data_type) :: ugrid_mesh_data
   type(global_mesh_type)     :: global_mesh
 
+    type(ugrid_2d_type), intent(inout) :: ugrid_2d
+
   if (.not. global_mesh_collection%check_for(mesh_name)) then
 
     write(log_scratch_space,'(A)') &
@@ -79,7 +83,7 @@ subroutine load_global_mesh_single( input_mesh_file, &
 
     ! Load mesh data into global_mesh
     call ugrid_mesh_data%read_from_file( trim(input_mesh_file), &
-                                         mesh_name )
+                                         mesh_name, ugrid_2d )
 
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()

--- a/components/driver/source/mesh/load_local_mesh_maps_mod.f90
+++ b/components/driver/source/mesh/load_local_mesh_maps_mod.f90
@@ -45,7 +45,7 @@ subroutine load_local_mesh_maps_multiple_source( input_mesh_file, &
   implicit none
 
   character(str_max_filename), intent(in) :: input_mesh_file
-  character(str_def),          intent(in) :: source_mesh_names(:)
+  character(str_def),          intent(inout) :: source_mesh_names(:)
   type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   integer(i_def) :: i
@@ -74,7 +74,7 @@ subroutine load_local_mesh_maps_single_source( input_mesh_file, &
   implicit none
 
   character(str_max_filename), intent(in) :: input_mesh_file
-  character(str_def),          intent(in) :: source_mesh_name
+  character(str_def),          intent(inout) :: source_mesh_name
 
   character(str_def), allocatable :: target_mesh_names(:)
   integer(i_def),     allocatable :: lid_mesh_map(:,:,:)

--- a/components/driver/source/mesh/load_local_mesh_maps_mod.f90
+++ b/components/driver/source/mesh/load_local_mesh_maps_mod.f90
@@ -105,7 +105,7 @@ subroutine load_local_mesh_maps_single_source( input_mesh_file, &
       if ( local_mesh_collection%check_for( target_mesh_names(i) ) ) then
 
         ! Read in the local mesh map.
-        call ugrid_2d%file_handler%read_map( source_mesh_name,     &
+        call ugrid_2d%file_handler_read_map( source_mesh_name,     &
                                     target_mesh_names(i), &
                                     lid_mesh_map )
 

--- a/components/driver/source/mesh/load_local_mesh_maps_mod.f90
+++ b/components/driver/source/mesh/load_local_mesh_maps_mod.f90
@@ -12,7 +12,7 @@ module load_local_mesh_maps_mod
                                        log_scratch_space, &
                                        LOG_LEVEL_ERROR
   use ncdf_quad_mod,             only: ncdf_quad_type
-    use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
 
 
   use local_mesh_collection_mod, only: local_mesh_collection
@@ -106,8 +106,8 @@ subroutine load_local_mesh_maps_single_source( input_mesh_file, &
 
         ! Read in the local mesh map.
         call ugrid_2d%file_handler_read_map( source_mesh_name,     &
-                                    target_mesh_names(i), &
-                                    lid_mesh_map )
+                                             target_mesh_names(i), &
+                                             lid_mesh_map )
 
         target_mesh &
             => local_mesh_collection%get_local_mesh(target_mesh_names(i))

--- a/components/driver/source/mesh/load_local_mesh_maps_mod.f90
+++ b/components/driver/source/mesh/load_local_mesh_maps_mod.f90
@@ -12,6 +12,7 @@ module load_local_mesh_maps_mod
                                        log_scratch_space, &
                                        LOG_LEVEL_ERROR
   use ncdf_quad_mod,             only: ncdf_quad_type
+    use ugrid_2d_mod,   only: ugrid_2d_type
 
 
   use local_mesh_collection_mod, only: local_mesh_collection
@@ -39,18 +40,19 @@ contains
 !> @param[in]  source_mesh_name   The name of the local source mesh to
 !>                                load maps from the <input_mesh_file>.
 subroutine load_local_mesh_maps_multiple_source( input_mesh_file, &
-                                                 source_mesh_names )
+                                                 source_mesh_names, ugrid_2d )
 
   implicit none
 
   character(str_max_filename), intent(in) :: input_mesh_file
   character(str_def),          intent(in) :: source_mesh_names(:)
+  type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   integer(i_def) :: i
 
   do i=1, size(source_mesh_names)
     call load_local_mesh_maps_single_source( input_mesh_file, &
-                                             source_mesh_names(i) )
+                                             source_mesh_names(i), ugrid_2d )
   end do
 
 end subroutine load_local_mesh_maps_multiple_source
@@ -67,7 +69,7 @@ end subroutine load_local_mesh_maps_multiple_source
 !> @param[in]  source_mesh_name   The name of the local source mesh to load
 !>                                maps from the <input_mesh_file>.
 subroutine load_local_mesh_maps_single_source( input_mesh_file, &
-                                               source_mesh_name )
+                                               source_mesh_name, ugrid_2d )
 
   implicit none
 
@@ -79,10 +81,9 @@ subroutine load_local_mesh_maps_single_source( input_mesh_file, &
 
   integer(i_def) :: i
 
-  type(ncdf_quad_type) :: file_handler
-
   type(local_mesh_type), pointer :: source_mesh => null()
   type(local_mesh_type), pointer :: target_mesh => null()
+  type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   integer(i_def) :: target_mesh_id
 
@@ -100,13 +101,11 @@ subroutine load_local_mesh_maps_single_source( input_mesh_file, &
 
   if (allocated(target_mesh_names)) then
 
-    call file_handler%file_open(trim(input_mesh_file))
-
     do i=1, size(target_mesh_names)
       if ( local_mesh_collection%check_for( target_mesh_names(i) ) ) then
 
         ! Read in the local mesh map.
-        call file_handler%read_map( source_mesh_name,     &
+        call ugrid_2d%file_handler%read_map( source_mesh_name,     &
                                     target_mesh_names(i), &
                                     lid_mesh_map )
 
@@ -122,8 +121,6 @@ subroutine load_local_mesh_maps_single_source( input_mesh_file, &
 
       end if
     end do
-
-    call file_handler%file_close()
 
     deallocate( target_mesh_names )
 

--- a/components/driver/source/mesh/load_local_mesh_mod.f90
+++ b/components/driver/source/mesh/load_local_mesh_mod.f90
@@ -16,6 +16,7 @@ module load_local_mesh_mod
   use sci_query_mod,       only: is_lbc
 
   use local_mesh_collection_mod, only: local_mesh_collection
+  use ugrid_2d_mod,   only: ugrid_2d_type
 
   implicit none
 
@@ -37,16 +38,17 @@ contains
 !> @param[in] mesh_names       The names of the local mesh data to
 !>                             load from the <input_mesh_file>.
 subroutine load_local_mesh_multiple( input_mesh_file, &
-                                     mesh_names )
+                                     mesh_names, ugrid_2d )
   implicit none
 
   character(str_max_filename), intent(in) :: input_mesh_file
   character(str_def),          intent(in) :: mesh_names(:)
 
   integer(i_def) :: i
+    type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   do i=1, size(mesh_names)
-    call load_local_mesh_single( input_mesh_file, mesh_names(i) )
+    call load_local_mesh_single( input_mesh_file, mesh_names(i), ugrid_2d )
   end do
 
 end subroutine load_local_mesh_multiple
@@ -59,7 +61,7 @@ end subroutine load_local_mesh_multiple
 !> @param[in] mesh_name        The name of the local mesh data to
 !>                             load from the <input_mesh_file>.
 subroutine load_local_mesh_single( input_mesh_file, &
-                                   mesh_name )
+                                   mesh_name, ugrid_2d )
 
   implicit none
 
@@ -70,11 +72,12 @@ subroutine load_local_mesh_single( input_mesh_file, &
   type(local_mesh_type)      :: local_mesh
 
   integer(i_def) :: local_mesh_id
+    type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   if (.not. local_mesh_collection%check_for(mesh_name)) then
 
     ! Load mesh data into local_mesh
-    call ugrid_mesh_data%read_from_file( input_mesh_file, mesh_name )
+    call ugrid_mesh_data%read_from_file( input_mesh_file, mesh_name, ugrid_2d )
 
     if (ugrid_mesh_data%contains_mesh()) then
 

--- a/components/driver/source/mesh/runtime_partition_mod.f90
+++ b/components/driver/source/mesh/runtime_partition_mod.f90
@@ -251,7 +251,7 @@ subroutine create_local_mesh_maps( input_mesh_file, ugrid_2d )
         if ( associated(target_local_mesh) ) then
 
           ! Read in the global mesh map
-          call ugrid_2d%file_handler%read_map( source_mesh_names(i), &
+          call ugrid_2d%file_handler_read_map( source_mesh_names(i), &
                                       target_mesh_names(j), &
                                       gid_mesh_map )
 

--- a/components/driver/source/mesh/runtime_partition_mod.f90
+++ b/components/driver/source/mesh/runtime_partition_mod.f90
@@ -28,6 +28,7 @@ module runtime_partition_mod
 
   use local_mesh_collection_mod,  only: local_mesh_collection
   use global_mesh_collection_mod, only: global_mesh_collection
+    use ugrid_2d_mod,   only: ugrid_2d_type
 
   implicit none
 
@@ -198,13 +199,13 @@ end subroutine create_local_mesh
 !!           mesh object.
 !!
 !> @param[in]  input_mesh_file  Input file to load mesh maps from.
-subroutine create_local_mesh_maps( input_mesh_file )
+subroutine create_local_mesh_maps( input_mesh_file, ugrid_2d )
 
   implicit none
 
   character(len=str_max_filename) :: input_mesh_file
 
-  type(ncdf_quad_type) :: file_handler
+    type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   character(str_def), allocatable :: source_mesh_names(:)
   character(str_def), allocatable :: target_mesh_names(:)
@@ -225,7 +226,6 @@ subroutine create_local_mesh_maps( input_mesh_file )
 
   ! Read in the maps for each global mesh
   !=================================================================
-  call file_handler%file_open(trim(input_mesh_file))
 
   allocate( source_mesh_names, &
             source=global_mesh_collection%get_mesh_names() )
@@ -251,7 +251,7 @@ subroutine create_local_mesh_maps( input_mesh_file )
         if ( associated(target_local_mesh) ) then
 
           ! Read in the global mesh map
-          call file_handler%read_map( source_mesh_names(i), &
+          call ugrid_2d%file_handler%read_map( source_mesh_names(i), &
                                       target_mesh_names(j), &
                                       gid_mesh_map )
 
@@ -295,8 +295,6 @@ subroutine create_local_mesh_maps( input_mesh_file )
   if ( allocated( source_mesh_names ) ) then
     deallocate( source_mesh_names)
   end if
-
-  call file_handler%file_close()
 
   return
 end subroutine create_local_mesh_maps

--- a/components/driver/source/mesh/runtime_partition_mod.f90
+++ b/components/driver/source/mesh/runtime_partition_mod.f90
@@ -28,7 +28,7 @@ module runtime_partition_mod
 
   use local_mesh_collection_mod,  only: local_mesh_collection
   use global_mesh_collection_mod, only: global_mesh_collection
-    use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
 
   implicit none
 
@@ -205,7 +205,7 @@ subroutine create_local_mesh_maps( input_mesh_file, ugrid_2d )
 
   character(len=str_max_filename) :: input_mesh_file
 
-    type(ugrid_2d_type), intent(inout) :: ugrid_2d
+  type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
   character(str_def), allocatable :: source_mesh_names(:)
   character(str_def), allocatable :: target_mesh_names(:)
@@ -252,8 +252,8 @@ subroutine create_local_mesh_maps( input_mesh_file, ugrid_2d )
 
           ! Read in the global mesh map
           call ugrid_2d%file_handler_read_map( source_mesh_names(i), &
-                                      target_mesh_names(j), &
-                                      gid_mesh_map )
+                                               target_mesh_names(j), &
+                                               gid_mesh_map )
 
           ! Create the local mesh map
           ntarget_per_source_cell_x = size(gid_mesh_map, 1)

--- a/components/driver/unit-test/mesh/create_mesh_mod_test.pf
+++ b/components/driver/unit-test/mesh/create_mesh_mod_test.pf
@@ -26,6 +26,9 @@ module create_mesh_mod_test
   use extrusion_config_mod,    only: method_uniform
   use partitioning_config_mod, only: panel_decomposition_auto, &
                                      partitioner_planar
+  use ugrid_2d_mod,            only: ugrid_2d_type
+  use ugrid_file_mod,          only: ugrid_file_type
+  use ncdf_quad_mod,           only: ncdf_quad_type
 
   use pfunit
 
@@ -94,6 +97,13 @@ contains
     integer(i_def)                                :: local_mesh_id
 
     logical(l_def), parameter :: enforce_constraints = .true.
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
 
     ! Reset in case of repeated initialisation
     call mesh_collection%clear()
@@ -104,7 +114,7 @@ contains
     nullify( partitioner_ptr )
 
     ! Read mesh from file and initialise mesh collections
-    call ugrid_mesh_data%read_from_file( trim( filename ), mesh_name )
+    call ugrid_mesh_data%read_from_file( trim( filename ), mesh_name, ugrid_2d )
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
     call global_mesh_collection%add_new_global_mesh( global_mesh )

--- a/infrastructure/source/io/ugrid_2d_mod.F90
+++ b/infrastructure/source/io/ugrid_2d_mod.F90
@@ -144,6 +144,7 @@ contains
   procedure :: set_file_handler
   procedure :: file_handler_open
   procedure :: file_handler_close
+  procedure :: file_handler_read_map
   procedure :: set_from_file_read
   procedure :: write_to_file
   procedure :: append_to_file
@@ -497,7 +498,7 @@ subroutine file_handler_open(self, filename)
   character(len=*),     intent(in) :: filename
 
   if ( .not. allocated (self%file_handler) ) then
-        call log_event('ugrid_2d file handler not set on open', log_level_error)
+    call log_event('ugrid_2d file handler not set on open', log_level_error)
   end if
   
   if ( .not. self%file_handler_file_open ) then
@@ -519,7 +520,7 @@ subroutine file_handler_close(self)
   class(ugrid_2d_type), intent(inout) :: self
 
   if ( .not. allocated (self%file_handler) ) then
-        call log_event('ugrid_2d file handler not set on close', log_level_error)
+    call log_event('ugrid_2d file handler not set on close', log_level_error)
   end if
   
   if ( self%file_handler_file_open ) then
@@ -529,6 +530,49 @@ subroutine file_handler_close(self)
   return
 end subroutine file_handler_close
 
+!-------------------------------------------------------------------------------
+!> @brief   Call `read-map` on the file_handler.
+!> @details Wrapper to enable the ugrid_2d object's file_handler to call its
+!>          `read_map` subroutine and pass through relevant arguments.
+!>          The file_handler must be set on the object and the file open.
+!>
+!>  @param[in]      source_mesh_name    Name of the source mesh object
+!>  @param[in]      target_mesh_name    Name of the target mesh object
+!>  @param[out]     mesh_map            Intergrid mapping array which maps
+!>                                      source mesh cells to target mesh
+!>                                      cells. Allocatable integer array,
+!>                                      returned as
+!>                                      [n target cells per source x,
+!>                                       n target cells per source y,
+!>                                       n source cells]
+!-------------------------------------------------------------------------------
+subroutine file_handler_read_map( self,             &
+                                  source_mesh_name, &
+                                  target_mesh_name, &
+                                  mesh_map )
+
+  implicit none
+
+  class(ugrid_2d_type), intent(inout) :: self
+  character(str_def), intent(inout)  :: source_mesh_name
+  character(str_def), intent(inout)  :: target_mesh_name
+  integer(i_def),     intent(out), allocatable :: mesh_map(:,:,:)
+
+  if ( .not. allocated (self%file_handler) ) then
+    call log_event('ugrid_2d file handler not set on close', log_level_error)
+  end if
+
+  if ( .not. self%file_handler_file_open ) then
+    call log_event('ugrid_2d file handler file not open on read_map', &
+                    log_level_error)
+  end if
+
+  call self%file_handler%read_map(source_mesh_name, &
+                                  target_mesh_name, &
+                                  mesh_map )
+
+  return
+end subroutine file_handler_read_map
 
 !-------------------------------------------------------------------------------
 !> @brief   Reads ugrid information and populates internal arrays.

--- a/infrastructure/source/io/ugrid_2d_mod.F90
+++ b/infrastructure/source/io/ugrid_2d_mod.F90
@@ -34,7 +34,7 @@ integer(i_def), parameter :: TOPOLOGY_DIMENSION  = 2
 !> @brief Stores 2-dimensional grid information.
 !-------------------------------------------------------------------------------
 type, public :: ugrid_2d_type
-  private
+  ! private
 
   character(str_def) :: mesh_name
 
@@ -258,9 +258,7 @@ subroutine get_mesh_names(self, filename, mesh_names)
   character(len=*),     intent(in)    :: filename
   character(len=*),     intent(out)   :: mesh_names(:)
 
-  call self%file_handler%file_open(trim(filename))
   call self%file_handler%get_mesh_names(mesh_names)
-  call self%file_handler%file_close()
 
   return
 end subroutine get_mesh_names
@@ -279,9 +277,7 @@ subroutine get_n_meshes(self, filename, n_meshes)
   character(len=*),     intent(in)    :: filename
   integer(i_def),       intent(out)   :: n_meshes
 
-  call self%file_handler%file_open(trim(filename))
   n_meshes = self%file_handler%get_n_meshes()
-  call self%file_handler%file_close()
 
   return
 end subroutine get_n_meshes
@@ -504,11 +500,10 @@ subroutine set_from_file_read(self, mesh_name, filename)
 
   self%mesh_name = trim(mesh_name)
 
-  call self%file_handler%file_open(trim(filename))
 
   if (.not. self%file_handler%is_mesh_present(trim(mesh_name))) then
     self%populated_with_mesh = .false.
-    call self%file_handler%file_close()
+
     return
   end if
 
@@ -548,7 +543,7 @@ subroutine set_from_file_read(self, mesh_name, filename)
        self%nmaps, self%target_mesh_names )
 
 
-  call self%file_handler%file_close()
+  ! call self%file_handler%file_close()
 
   self%populated_with_mesh = .true.
 

--- a/infrastructure/source/io/ugrid_2d_mod.F90
+++ b/infrastructure/source/io/ugrid_2d_mod.F90
@@ -500,7 +500,7 @@ subroutine file_handler_open(self, filename)
   if ( .not. allocated (self%file_handler) ) then
     call log_event('ugrid_2d file handler not set on open', log_level_error)
   end if
-  
+
   if ( .not. self%file_handler_file_open ) then
     call self%file_handler%file_open(trim(filename))
     self%file_handler_file_open = .true.
@@ -522,7 +522,7 @@ subroutine file_handler_close(self)
   if ( .not. allocated (self%file_handler) ) then
     call log_event('ugrid_2d file handler not set on close', log_level_error)
   end if
-  
+
   if ( self%file_handler_file_open ) then
     call self%file_handler%file_close()
     self%file_handler_file_open = .false.

--- a/infrastructure/source/io/ugrid_2d_mod.F90
+++ b/infrastructure/source/io/ugrid_2d_mod.F90
@@ -15,6 +15,7 @@ use constants_mod,  only: i_def, r_def, str_def, str_longlong, l_def, &
                           imdi, rmdi, cmdi
 use file_mod,       only: file_mode_write
 use ugrid_file_mod, only: ugrid_file_type
+use log_mod,        only: log_event, log_level_error
 
 
 use local_mesh_map_collection_mod,  only: local_mesh_map_collection_type
@@ -34,7 +35,7 @@ integer(i_def), parameter :: TOPOLOGY_DIMENSION  = 2
 !> @brief Stores 2-dimensional grid information.
 !-------------------------------------------------------------------------------
 type, public :: ugrid_2d_type
-  ! private
+  private
 
   character(str_def) :: mesh_name
 
@@ -133,6 +134,7 @@ type, public :: ugrid_2d_type
   class(ugrid_file_type), allocatable :: file_handler
 
   logical :: populated_with_mesh = .false.
+  logical :: file_handler_file_open = .false.
 
 contains
   procedure :: get_n_meshes
@@ -140,6 +142,8 @@ contains
   procedure :: get_dimensions
   procedure :: set_by_generator
   procedure :: set_file_handler
+  procedure :: file_handler_open
+  procedure :: file_handler_close
   procedure :: set_from_file_read
   procedure :: write_to_file
   procedure :: append_to_file
@@ -480,6 +484,53 @@ subroutine set_file_handler(self, file_handler)
 end subroutine set_file_handler
 
 !-------------------------------------------------------------------------------
+!> @brief   Open the filename file using the file_handler
+!> @details Receives a filename and opens the filename using the
+!>          file_handler, which must be already set.
+!>
+!> @param[in] filename The filename to open.
+!-------------------------------------------------------------------------------
+subroutine file_handler_open(self, filename)
+  implicit none
+
+  class(ugrid_2d_type), intent(inout) :: self
+  character(len=*),     intent(in) :: filename
+
+  if ( .not. allocated (self%file_handler) ) then
+        call log_event('ugrid_2d file handler not set on open', log_level_error)
+  end if
+  
+  if ( .not. self%file_handler_file_open ) then
+    call self%file_handler%file_open(trim(filename))
+    self%file_handler_file_open = .true.
+  end if
+  return
+end subroutine file_handler_open
+
+!-------------------------------------------------------------------------------
+!> @brief   Closes the file using the file_handler
+!> @details Closes the file using the provided
+!>          file_handler, which must be already set.
+!>
+!-------------------------------------------------------------------------------
+subroutine file_handler_close(self)
+  implicit none
+
+  class(ugrid_2d_type), intent(inout) :: self
+
+  if ( .not. allocated (self%file_handler) ) then
+        call log_event('ugrid_2d file handler not set on close', log_level_error)
+  end if
+  
+  if ( self%file_handler_file_open ) then
+    call self%file_handler%file_close()
+    self%file_handler_file_open = .false.
+  end if
+  return
+end subroutine file_handler_close
+
+
+!-------------------------------------------------------------------------------
 !> @brief   Reads ugrid information and populates internal arrays.
 !> @details Calls back to the file handler strategy (component) in order to
 !>          read the ugrid mesh data and populate internal arrays with data
@@ -541,9 +592,6 @@ subroutine set_from_file_read(self, mesh_name, filename)
        self%edge_on_cell_gid,                                       &
 
        self%nmaps, self%target_mesh_names )
-
-
-  ! call self%file_handler%file_close()
 
   self%populated_with_mesh = .true.
 

--- a/infrastructure/source/mesh/ugrid_mesh_data_mod.f90
+++ b/infrastructure/source/mesh/ugrid_mesh_data_mod.f90
@@ -16,6 +16,7 @@ module ugrid_mesh_data_mod
                            str_longlong, cmdi, imdi, rmdi
   use log_mod,       only: log_event, log_scratch_space, &
                            LOG_LEVEL_ERROR, LOG_LEVEL_TRACE
+    use ugrid_2d_mod,   only: ugrid_2d_type
 
   implicit none
 
@@ -170,11 +171,7 @@ contains
   !> @param[in] global_mesh_name Name of ugrid mesh topology to create
   !>                             global mesh object from.
   !>
-  subroutine read_from_file( self, filename, global_mesh_name )
-
-    use ugrid_2d_mod,   only: ugrid_2d_type
-    use ugrid_file_mod, only: ugrid_file_type
-    use ncdf_quad_mod,  only: ncdf_quad_type
+  subroutine read_from_file( self, filename, global_mesh_name, ugrid_2d )
 
     implicit none
 
@@ -182,14 +179,10 @@ contains
     character(*),                 intent(in)    :: filename
     character(*),                 intent(in)    :: global_mesh_name
 
-    type(ugrid_2d_type) :: ugrid_2d
-
-    class(ugrid_file_type), allocatable :: file_handler
+    type(ugrid_2d_type), intent(inout) :: ugrid_2d
 
     call self%clear()
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
     call ugrid_2d%set_from_file_read( trim(global_mesh_name), trim(filename) )
 
     self%populated_with_mesh = .false.
@@ -204,8 +197,6 @@ contains
 
       self%populated_with_mesh = .true.
     end if
-
-    if (allocated(file_handler)) deallocate( file_handler )
 
   end subroutine read_from_file
 

--- a/infrastructure/unit-test/function_space/function_space_chain_mod_test.pf
+++ b/infrastructure/unit-test/function_space/function_space_chain_mod_test.pf
@@ -33,6 +33,9 @@ use local_mesh_collection_mod,     only: local_mesh_collection_type, &
                                          local_mesh_collection
 use ugrid_mesh_data_mod,           only: ugrid_mesh_data_type
 use panel_decomposition_mod,       only: custom_decomposition_type
+use ugrid_2d_mod,   only: ugrid_2d_type
+use ugrid_file_mod, only: ugrid_file_type
+use ncdf_quad_mod,  only: ncdf_quad_type
 
 implicit none
 
@@ -132,6 +135,13 @@ logical(l_def), parameter :: enforce_constraints = .true.
 
 procedure (partitioner_interface), pointer :: partitioner_ptr => null()
 type(custom_decomposition_type) :: decomposition
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler_
+
+    allocate( ncdf_quad_type :: file_handler_ )
+    call ugrid_2d%set_file_handler( file_handler_ )
+    call ugrid_2d%file_handler%file_open(trim(filename))
 
 call lfric_comm%set_comm_mpi_val(this%getMpiCommunicator())
 
@@ -150,7 +160,7 @@ function_space_collection = function_space_collection_type()
 
 ! Create all the meshes: global and local
 do i=1, size(mesh_names)
-  call ugrid_mesh_data%read_from_file(trim(filename), mesh_names(i))
+  call ugrid_mesh_data%read_from_file(trim(filename), mesh_names(i), ugrid_2d)
   global_mesh = global_mesh_type( ugrid_mesh_data )
   call ugrid_mesh_data%clear()
   call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -167,6 +177,8 @@ do i=1, size(mesh_names)
   call global_mesh%clear()
   call local_mesh%clear()
 enddo
+call ugrid_2d%file_handler%file_close()
+if (allocated(file_handler_)) deallocate( file_handler_ )
 
 ! Now all the meshes exist, read in global mesh maps, convert them to local ids
 ! and associate them with the approprate source local mesh

--- a/infrastructure/unit-test/function_space/function_space_chain_mod_test.pf
+++ b/infrastructure/unit-test/function_space/function_space_chain_mod_test.pf
@@ -141,7 +141,7 @@ type(custom_decomposition_type) :: decomposition
 
     allocate( ncdf_quad_type :: file_handler_ )
     call ugrid_2d%set_file_handler( file_handler_ )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 call lfric_comm%set_comm_mpi_val(this%getMpiCommunicator())
 
@@ -177,7 +177,7 @@ do i=1, size(mesh_names)
   call global_mesh%clear()
   call local_mesh%clear()
 enddo
-call ugrid_2d%file_handler%file_close()
+call ugrid_2d%file_handler_close()
 if (allocated(file_handler_)) deallocate( file_handler_ )
 
 ! Now all the meshes exist, read in global mesh maps, convert them to local ids

--- a/infrastructure/unit-test/mesh/global_mesh_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/global_mesh_collection_mod_test.pf
@@ -100,7 +100,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     filename = CubedSphereFile
@@ -108,7 +108,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -143,7 +143,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     filename = BiPeriodicFile
@@ -151,7 +151,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -245,7 +245,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler_ )
     call ugrid_2d%set_file_handler( file_handler_ )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     ! First read all the requested global meshes into memory.
@@ -269,7 +269,7 @@ contains
       call ugrid_mesh_data%clear()
       call global_mesh_collection%add_new_global_mesh( global_mesh )
     end do
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! Now get the ids of the `chains` from the collection

--- a/infrastructure/unit-test/mesh/global_mesh_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/global_mesh_collection_mod_test.pf
@@ -16,6 +16,9 @@ module global_mesh_collection_mod_test
   use global_mesh_collection_mod,     only: global_mesh_collection_type, &
                                             global_mesh_collection
   use ugrid_mesh_data_mod,            only: ugrid_mesh_data_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use funit
 
@@ -91,12 +94,22 @@ contains
     character(str_max_filename)     :: filename
 
     integer (i_def) :: global_mesh_id
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     filename = CubedSphereFile
 
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
     global_mesh_ptr => global_mesh_collection % &
@@ -124,12 +137,22 @@ contains
     character(str_max_filename)     :: filename
 
     integer (i_def) :: global_mesh_id
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     filename = BiPeriodicFile
 
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
     global_mesh_ptr => global_mesh_collection % &
@@ -216,6 +239,14 @@ contains
     integer (i_def) :: kgo_integer
 
     type(ncdf_quad_type) :: file_handler
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler_
+
+    allocate( ncdf_quad_type :: file_handler_ )
+    call ugrid_2d%set_file_handler( file_handler_ )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     ! First read all the requested global meshes into memory.
     ! This is done because the intergrid map ids are based
@@ -224,7 +255,7 @@ contains
     do i=1, size(multigrid_mesh_names)
 
       call ugrid_mesh_data%read_from_file( trim(filename), &
-                                           multigrid_mesh_names(i) )
+                                           multigrid_mesh_names(i), ugrid_2d )
       global_mesh = global_mesh_type( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
       multigrid_ids(i) = global_mesh%get_id()
@@ -233,11 +264,13 @@ contains
 
     do i=1, size(another_chain)
       call ugrid_mesh_data%read_from_file( trim(filename), &
-                                           another_chain(i) )
+                                           another_chain(i), ugrid_2d )
       global_mesh = global_mesh_type( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
       call global_mesh_collection%add_new_global_mesh( global_mesh )
     end do
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! Now get the ids of the `chains` from the collection
     do i=1, size(multigrid_mesh_names)

--- a/infrastructure/unit-test/mesh/global_mesh_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/global_mesh_collection_mod_test.pf
@@ -98,12 +98,10 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
+    filename = CubedSphereFile
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
     call ugrid_2d%file_handler_open(trim(filename))
-
-
-    filename = CubedSphereFile
 
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
@@ -141,12 +139,10 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
+    filename = BiPeriodicFile
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
     call ugrid_2d%file_handler_open(trim(filename))
-
-
-    filename = BiPeriodicFile
 
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )

--- a/infrastructure/unit-test/mesh/global_mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/global_mesh_mod_test.pf
@@ -108,7 +108,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     !-------------------------------------
@@ -119,7 +119,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
     ! Check the global mesh id
@@ -277,7 +277,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     !---------------------------------------
@@ -287,7 +287,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
     ! Check the global mesh id
@@ -446,7 +446,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     filename='data/mesh_C32_MG.nc'
@@ -457,7 +457,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
     ! Check details of C4 mesh
@@ -579,7 +579,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler_ )
     call ugrid_2d%set_file_handler( file_handler_ )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     !-------------------------------------------------
@@ -601,7 +601,7 @@ contains
       MultiGrid_ids(i) = global_mesh%get_id()
       call global_mesh_collection%add_new_global_mesh( global_mesh )
     end do
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! Check that each ID appears only once

--- a/infrastructure/unit-test/mesh/global_mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/global_mesh_mod_test.pf
@@ -106,16 +106,15 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     !-------------------------------------
     ! Test construction of a biperiodic mesh
     !-------------------------------------
 
     filename = 'data/mesh_BiP8x8-750x250.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
+
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
@@ -275,15 +274,14 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     !---------------------------------------
     ! Test construction of a cubed-sphere mesh
     !---------------------------------------
     filename = 'data/mesh_C4.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
+
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
@@ -444,12 +442,10 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
+    filename='data/mesh_C32_MG.nc'
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
     call ugrid_2d%file_handler_open(trim(filename))
-
-
-    filename='data/mesh_C32_MG.nc'
     !-------------------------------------------------
     ! Test construction of a cubed-sphere mesh is same
     !-------------------------------------------------
@@ -577,11 +573,6 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler_
 
-    allocate( ncdf_quad_type :: file_handler_ )
-    call ugrid_2d%set_file_handler( file_handler_ )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     !-------------------------------------------------
     ! Test construction of a cubed-sphere mesh is same
     !-------------------------------------------------
@@ -589,6 +580,9 @@ contains
 
     npanels  = 6
     filename='data/mesh_C32_MG.nc'
+    allocate( ncdf_quad_type :: file_handler_ )
+    call ugrid_2d%set_file_handler( file_handler_ )
+    call ugrid_2d%file_handler_open(trim(filename))
 
     ! 1.0 First read all the requested global meshes into memory.
     ! This is done because the intergrid map ids are based

--- a/infrastructure/unit-test/mesh/global_mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/global_mesh_mod_test.pf
@@ -16,6 +16,9 @@ module global_mesh_mod_test
   use global_mesh_collection_mod, only: global_mesh_collection_type, &
                                         global_mesh_collection
   use ugrid_mesh_data_mod,        only: ugrid_mesh_data_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use funit
 
@@ -99,15 +102,25 @@ contains
 
     real(r_def)    :: vert_coords(2)
     real(r_def)    :: cell_coords(2)
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     !-------------------------------------
     ! Test construction of a biperiodic mesh
     !-------------------------------------
 
     filename = 'data/mesh_BiP8x8-750x250.nc'
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
 
     ! Check the global mesh id
     global_mesh_id1 = global_mesh%get_id()
@@ -258,14 +271,24 @@ contains
 
     real(r_def)    :: cell_coords(2)
     real(r_def)    :: vert_coords(2)
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     !---------------------------------------
     ! Test construction of a cubed-sphere mesh
     !---------------------------------------
     filename = 'data/mesh_C4.nc'
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
 
     ! Check the global mesh id
     global_mesh_id2 = global_mesh%get_id()
@@ -417,15 +440,25 @@ contains
 
     type(global_mesh_type) :: global_mesh
     character(str_def)     :: mesh_name = 'C4'
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     filename='data/mesh_C32_MG.nc'
     !-------------------------------------------------
     ! Test construction of a cubed-sphere mesh is same
     !-------------------------------------------------
     mesh_name = 'C4'
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
 
     ! Check details of C4 mesh
 
@@ -540,6 +573,14 @@ contains
     type(global_mesh_map_type), pointer :: global_mesh_map => null()
     type(global_mesh_type)              :: global_mesh
     integer(i_def), allocatable         :: mesh_map(:,:,:)
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler_
+
+    allocate( ncdf_quad_type :: file_handler_ )
+    call ugrid_2d%set_file_handler( file_handler_ )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     !-------------------------------------------------
     ! Test construction of a cubed-sphere mesh is same
@@ -554,12 +595,14 @@ contains
     ! on the global mesh ids. So all the required global mesh
     ! topologies must be read in first.
     do i=1, size(multigrid_mesh_names)
-      call ugrid_mesh_data%read_from_file(trim(filename), multigrid_mesh_names(i))
+      call ugrid_mesh_data%read_from_file(trim(filename), multigrid_mesh_names(i), ugrid_2d)
       global_mesh = global_mesh_type( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
       MultiGrid_ids(i) = global_mesh%get_id()
       call global_mesh_collection%add_new_global_mesh( global_mesh )
     end do
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! Check that each ID appears only once
     !

--- a/infrastructure/unit-test/mesh/local_mesh_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/local_mesh_collection_mod_test.pf
@@ -109,7 +109,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
     filename = 'data/mesh_BiP8x8-750x250.nc'
     mesh_name = 'unit_test'
@@ -117,7 +117,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )

--- a/infrastructure/unit-test/mesh/local_mesh_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/local_mesh_collection_mod_test.pf
@@ -107,12 +107,12 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
+    filename = 'data/mesh_BiP8x8-750x250.nc'
+    mesh_name = 'unit_test'
+
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
     call ugrid_2d%file_handler_open(trim(filename))
-
-    filename = 'data/mesh_BiP8x8-750x250.nc'
-    mesh_name = 'unit_test'
 
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )

--- a/infrastructure/unit-test/mesh/local_mesh_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/local_mesh_collection_mod_test.pf
@@ -23,6 +23,9 @@ module local_mesh_collection_mod_test
                                          partitioner_interface
   use ugrid_mesh_data_mod,        only : ugrid_mesh_data_type
   use panel_decomposition_mod,    only : custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use pfunit
 
@@ -100,13 +103,22 @@ contains
 
     logical(l_def) :: generate_inner_halos
     logical(l_def), parameter :: enforce_constraints = .false.
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
 
     filename = 'data/mesh_BiP8x8-750x250.nc'
     mesh_name = 'unit_test'
 
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
     global_mesh_ptr => global_mesh_collection%get_global_mesh( global_mesh_id )

--- a/infrastructure/unit-test/mesh/local_mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/local_mesh_mod_test.pf
@@ -153,7 +153,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     ! Create a local mesh from partitioning a global mesh on 1 and 4 processors
@@ -166,7 +166,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -503,7 +503,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler_ )
     call ugrid_2d%set_file_handler( file_handler_ )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     npanels  = 6
@@ -532,7 +532,7 @@ contains
       call local_mesh(i)%initialise( global_mesh_ptr, partition )
       nullify(global_mesh_ptr)
     end do
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler_)) deallocate( file_handler_ )
 
     nullify(partitioner_ptr)
@@ -797,7 +797,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler_ )
     call ugrid_2d%set_file_handler( file_handler_ )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     !===========================================================================
@@ -809,7 +809,7 @@ contains
       call local_meshes(i)%initialise( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
     end do
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! 2.0 Read in local mesh_maps

--- a/infrastructure/unit-test/mesh/local_mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/local_mesh_mod_test.pf
@@ -151,16 +151,15 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     ! Create a local mesh from partitioning a global mesh on 1 and 4 processors
 
     num_processes = this%context%getNumProcesses()
 
     filename = 'data/mesh_BiP8x8-750x250.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
+
     mesh_name = 'unit_test'
     npanels  = 1
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
@@ -501,13 +500,11 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler_
 
+    npanels  = 6
+    filename='data/mesh_C32_MG.nc'
     allocate( ncdf_quad_type :: file_handler_ )
     call ugrid_2d%set_file_handler( file_handler_ )
     call ugrid_2d%file_handler_open(trim(filename))
-
-
-    npanels  = 6
-    filename='data/mesh_C32_MG.nc'
 
     xproc = 1
     yproc = 1

--- a/infrastructure/unit-test/mesh/local_mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/local_mesh_mod_test.pf
@@ -28,6 +28,9 @@ module local_mesh_mod_test
                                         partitioner_interface
   use ugrid_mesh_data_mod,        only: ugrid_mesh_data_type
   use panel_decomposition_mod,    only: custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   implicit none
 
@@ -144,6 +147,14 @@ contains
     logical(l_def), parameter :: enforce_constraints = .false.
 
     logical(l_def) :: answer
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     ! Create a local mesh from partitioning a global mesh on 1 and 4 processors
 
@@ -152,9 +163,11 @@ contains
     filename = 'data/mesh_BiP8x8-750x250.nc'
     mesh_name = 'unit_test'
     npanels  = 1
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
     global_mesh_ptr => global_mesh_collection%get_global_mesh( global_mesh_id )
@@ -484,6 +497,14 @@ contains
     type(local_mesh_type), target :: local_mesh(2)
     type(local_mesh_map_type), pointer :: local_mesh_map
     integer(i_def), allocatable :: mesh_map(:,:,:)
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler_
+
+    allocate( ncdf_quad_type :: file_handler_ )
+    call ugrid_2d%set_file_handler( file_handler_ )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     npanels  = 6
     filename='data/mesh_C32_MG.nc'
@@ -499,7 +520,7 @@ contains
     partitioner_ptr => partitioner_cubedsphere_serial
     decomposition = custom_decomposition_type(xproc, yproc)
     do i=1, size(mesh_names)
-      call ugrid_mesh_data%read_from_file(trim(filename), mesh_names(i))
+      call ugrid_mesh_data%read_from_file(trim(filename), mesh_names(i), ugrid_2d)
       global_mesh = global_mesh_type( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
       global_mesh_ptr => global_mesh
@@ -511,6 +532,8 @@ contains
       call local_mesh(i)%initialise( global_mesh_ptr, partition )
       nullify(global_mesh_ptr)
     end do
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler_)) deallocate( file_handler_ )
 
     nullify(partitioner_ptr)
 
@@ -768,16 +791,26 @@ contains
                41,void,42,void,  43,44,void,void,              &
                45,46,void,void,  47,48,void,void,              &
                49,void,void,void ], (/ 2, 2, 16/) )
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler_
+
+    allocate( ncdf_quad_type :: file_handler_ )
+    call ugrid_2d%set_file_handler( file_handler_ )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     !===========================================================================
     ! Setup
     !===========================================================================
     ! 1.0 Read in local meshes
     do i=1, size(mesh_names)
-      call ugrid_mesh_data%read_from_file( filename, mesh_names(i) )
+      call ugrid_mesh_data%read_from_file( filename, mesh_names(i), ugrid_2d )
       call local_meshes(i)%initialise( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
     end do
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! 2.0 Read in local mesh_maps
     call file_handler%file_open(filename)

--- a/infrastructure/unit-test/mesh/mesh_colouring_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_colouring_mod_test.pf
@@ -20,6 +20,9 @@ module mesh_colouring_mod_test
   use local_mesh_mod,             only : local_mesh_type
   use ugrid_mesh_data_mod,        only : ugrid_mesh_data_type
   use panel_decomposition_mod, only: custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   implicit none
 
@@ -132,11 +135,22 @@ subroutine test_compute_colours_cubedsphere(this)
 
   logical(l_def), parameter :: generate_inner_halos = .true.
   logical(l_def), parameter :: enforce_constraints  = .false.
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
 
   filename = "data/mesh_C4.nc"
-  call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
-  global_mesh = global_mesh_type( ugrid_mesh_data )
-  call ugrid_mesh_data%clear()
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+    ! Run through mesh construction process to initialise tiling via
+    ! the mesh_type API
+    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
+    global_mesh = global_mesh_type( ugrid_mesh_data )
+    call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
+
   global_mesh_ptr => global_mesh
   decomposition = custom_decomposition_type(this%xproc, this%yproc)
 
@@ -259,11 +273,22 @@ subroutine test_compute_colours_biperiodic(this)
   logical(l_def), parameter :: generate_inner_halos = .true.
   logical(l_def), parameter :: enforce_constraints  = .false.
   integer(i_def), parameter :: max_stencil_depth    = 1
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
 
   filename = "data/mesh_BiP8x8-750x250.nc"
-  call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
-  global_mesh = global_mesh_type( ugrid_mesh_data )
-  call ugrid_mesh_data%clear()
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+    ! Run through mesh construction process to initialise tiling via
+    ! the mesh_type API
+    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
+    global_mesh = global_mesh_type( ugrid_mesh_data )
+    call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
+
   global_mesh_ptr => global_mesh
   decomposition = custom_decomposition_type(this%xproc, this%yproc)
 
@@ -362,13 +387,22 @@ subroutine test_compute_colours_generic(this)
   logical(l_def), parameter :: generate_inner_halos = .true.
   logical(l_def), parameter :: enforce_constraints  = .false.
   integer(i_def), parameter :: max_stencil_depth    = 1
+    type(ugrid_2d_type) :: ugrid_2d
 
+    class(ugrid_file_type), allocatable :: file_handler
+
+  filename = "data/mesh_C4.nc"
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
   ! Force colour generator to use generic colour routine by not saying
   ! it's a cubed sphere
-  filename = "data/mesh_C4.nc"
-  call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
-  global_mesh = global_mesh_type( ugrid_mesh_data )
-  call ugrid_mesh_data%clear()
+    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
+    global_mesh = global_mesh_type( ugrid_mesh_data )
+    call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
+
   global_mesh_ptr => global_mesh
 
   partitioner_ptr => partitioner_cubedsphere_serial

--- a/infrastructure/unit-test/mesh/mesh_colouring_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_colouring_mod_test.pf
@@ -142,13 +142,13 @@ subroutine test_compute_colours_cubedsphere(this)
   filename = "data/mesh_C4.nc"
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
     ! Run through mesh construction process to initialise tiling via
     ! the mesh_type API
     call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
   global_mesh_ptr => global_mesh
@@ -280,13 +280,13 @@ subroutine test_compute_colours_biperiodic(this)
   filename = "data/mesh_BiP8x8-750x250.nc"
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
     ! Run through mesh construction process to initialise tiling via
     ! the mesh_type API
     call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
   global_mesh_ptr => global_mesh
@@ -394,13 +394,13 @@ subroutine test_compute_colours_generic(this)
   filename = "data/mesh_C4.nc"
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
   ! Force colour generator to use generic colour routine by not saying
   ! it's a cubed sphere
     call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
   global_mesh_ptr => global_mesh

--- a/infrastructure/unit-test/mesh/mesh_colouring_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_colouring_mod_test.pf
@@ -135,21 +135,21 @@ subroutine test_compute_colours_cubedsphere(this)
 
   logical(l_def), parameter :: generate_inner_halos = .true.
   logical(l_def), parameter :: enforce_constraints  = .false.
-    type(ugrid_2d_type) :: ugrid_2d
+  type(ugrid_2d_type) :: ugrid_2d
 
-    class(ugrid_file_type), allocatable :: file_handler
+  class(ugrid_file_type), allocatable :: file_handler
 
   filename = "data/mesh_C4.nc"
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-    ! Run through mesh construction process to initialise tiling via
-    ! the mesh_type API
-    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
-    global_mesh = global_mesh_type( ugrid_mesh_data )
-    call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler_close()
-    if (allocated(file_handler)) deallocate( file_handler )
+  allocate( ncdf_quad_type :: file_handler )
+  call ugrid_2d%set_file_handler( file_handler )
+  call ugrid_2d%file_handler_open(trim(filename))
+  ! Run through mesh construction process to initialise tiling via
+  ! the mesh_type API
+  call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
+  global_mesh = global_mesh_type( ugrid_mesh_data )
+  call ugrid_mesh_data%clear()
+  call ugrid_2d%file_handler_close()
+  if (allocated(file_handler)) deallocate( file_handler )
 
   global_mesh_ptr => global_mesh
   decomposition = custom_decomposition_type(this%xproc, this%yproc)
@@ -273,21 +273,21 @@ subroutine test_compute_colours_biperiodic(this)
   logical(l_def), parameter :: generate_inner_halos = .true.
   logical(l_def), parameter :: enforce_constraints  = .false.
   integer(i_def), parameter :: max_stencil_depth    = 1
-    type(ugrid_2d_type) :: ugrid_2d
+  type(ugrid_2d_type) :: ugrid_2d
 
-    class(ugrid_file_type), allocatable :: file_handler
+  class(ugrid_file_type), allocatable :: file_handler
 
   filename = "data/mesh_BiP8x8-750x250.nc"
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-    ! Run through mesh construction process to initialise tiling via
-    ! the mesh_type API
-    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
-    global_mesh = global_mesh_type( ugrid_mesh_data )
-    call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler_close()
-    if (allocated(file_handler)) deallocate( file_handler )
+  allocate( ncdf_quad_type :: file_handler )
+  call ugrid_2d%set_file_handler( file_handler )
+  call ugrid_2d%file_handler_open(trim(filename))
+  ! Run through mesh construction process to initialise tiling via
+  ! the mesh_type API
+  call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
+  global_mesh = global_mesh_type( ugrid_mesh_data )
+  call ugrid_mesh_data%clear()
+  call ugrid_2d%file_handler_close()
+  if (allocated(file_handler)) deallocate( file_handler )
 
   global_mesh_ptr => global_mesh
   decomposition = custom_decomposition_type(this%xproc, this%yproc)
@@ -387,21 +387,21 @@ subroutine test_compute_colours_generic(this)
   logical(l_def), parameter :: generate_inner_halos = .true.
   logical(l_def), parameter :: enforce_constraints  = .false.
   integer(i_def), parameter :: max_stencil_depth    = 1
-    type(ugrid_2d_type) :: ugrid_2d
+  type(ugrid_2d_type) :: ugrid_2d
 
-    class(ugrid_file_type), allocatable :: file_handler
+  class(ugrid_file_type), allocatable :: file_handler
 
   filename = "data/mesh_C4.nc"
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
+  allocate( ncdf_quad_type :: file_handler )
+  call ugrid_2d%set_file_handler( file_handler )
+  call ugrid_2d%file_handler_open(trim(filename))
   ! Force colour generator to use generic colour routine by not saying
   ! it's a cubed sphere
-    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
-    global_mesh = global_mesh_type( ugrid_mesh_data )
-    call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler_close()
-    if (allocated(file_handler)) deallocate( file_handler )
+  call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
+  global_mesh = global_mesh_type( ugrid_mesh_data )
+  call ugrid_mesh_data%clear()
+  call ugrid_2d%file_handler_close()
+  if (allocated(file_handler)) deallocate( file_handler )
 
   global_mesh_ptr => global_mesh
 

--- a/infrastructure/unit-test/mesh/mesh_map_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_map_collection_mod_test.pf
@@ -98,7 +98,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
     call lfric_comm%set_comm_mpi_val(this%getMpiCommunicator())
 
@@ -141,7 +141,7 @@ contains
     fine_global_mesh = global_mesh_type( ugrid_mesh_data )
     fine_global_mesh_ptr => fine_global_mesh
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
     fine_partition   = partition_type( fine_global_mesh_ptr,   &

--- a/infrastructure/unit-test/mesh/mesh_map_collection_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_map_collection_mod_test.pf
@@ -24,6 +24,9 @@ module mesh_map_collection_mod_test
                                         partitioner_cubedsphere_serial
   use ugrid_mesh_data_mod,        only: ugrid_mesh_data_type
   use panel_decomposition_mod, only: custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use pfunit
 
@@ -89,6 +92,13 @@ contains
     procedure (partitioner_interface), pointer :: partitioner_ptr => null()
     type(custom_decomposition_type) :: decomposition
     type(lfric_comm_type) :: lfric_comm
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
 
     call lfric_comm%set_comm_mpi_val(this%getMpiCommunicator())
 
@@ -106,7 +116,7 @@ contains
 
     ! Get coarse mesh
     name = 'C4'
-    call ugrid_mesh_data%read_from_file(trim(filename), name)
+    call ugrid_mesh_data%read_from_file(trim(filename), name, ugrid_2d)
     coarse_global_mesh = global_mesh_type( ugrid_mesh_data )
     coarse_global_mesh_ptr => coarse_global_mesh
     call ugrid_mesh_data%clear()
@@ -127,10 +137,12 @@ contains
     this%coarse_mesh = mesh_type( coarse_local_mesh_ptr, extrusion )
     ! Get fine mesh
     name = 'C8'
-    call ugrid_mesh_data%read_from_file(trim(filename), name)
+    call ugrid_mesh_data%read_from_file(trim(filename), name, ugrid_2d)
     fine_global_mesh = global_mesh_type( ugrid_mesh_data )
     fine_global_mesh_ptr => fine_global_mesh
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
 
     fine_partition   = partition_type( fine_global_mesh_ptr,   &
                                        partitioner_ptr,        &

--- a/infrastructure/unit-test/mesh/mesh_map_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_map_mod_test.pf
@@ -172,7 +172,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
     call lfric_comm%set_comm_mpi_val(this%getMpiCommunicator())
 
@@ -215,7 +215,7 @@ contains
     fine_global_mesh = global_mesh_type( ugrid_mesh_data )
     fine_global_mesh_ptr => fine_global_mesh
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
     fine_partition   = partition_type( fine_global_mesh_ptr,   &

--- a/infrastructure/unit-test/mesh/mesh_map_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_map_mod_test.pf
@@ -23,6 +23,9 @@ module mesh_map_mod_test
                                         partitioner_cubedsphere_serial
   use ugrid_mesh_data_mod,        only: ugrid_mesh_data_type
   use panel_decomposition_mod,    only: custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use pfunit
 
@@ -163,6 +166,13 @@ contains
     procedure (partitioner_interface), pointer :: partitioner_ptr => null()
     type(custom_decomposition_type) :: decomposition
     type(lfric_comm_type) :: lfric_comm
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
 
     call lfric_comm%set_comm_mpi_val(this%getMpiCommunicator())
 
@@ -180,7 +190,7 @@ contains
 
     ! Get coarse mesh
     name = 'C4'
-    call ugrid_mesh_data%read_from_file(trim(filename), name)
+    call ugrid_mesh_data%read_from_file( trim(filename), name, ugrid_2d )
     coarse_global_mesh = global_mesh_type( ugrid_mesh_data )
     coarse_global_mesh_ptr => coarse_global_mesh
     call ugrid_mesh_data%clear()
@@ -201,10 +211,12 @@ contains
     this%coarse_mesh = mesh_type( coarse_local_mesh_ptr, extrusion )
     ! Get fine mesh
     name = 'C8'
-    call ugrid_mesh_data%read_from_file(trim(filename), name)
+    call ugrid_mesh_data%read_from_file( trim(filename), name, ugrid_2d )
     fine_global_mesh = global_mesh_type( ugrid_mesh_data )
     fine_global_mesh_ptr => fine_global_mesh
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
 
     fine_partition   = partition_type( fine_global_mesh_ptr,   &
                                        partitioner_ptr,        &

--- a/infrastructure/unit-test/mesh/mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_mod_test.pf
@@ -819,7 +819,7 @@ contains
 
     ! Create all the meshes: global and local
     do i=1, size(mesh_names)
-      call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
+      call ugrid_mesh_data%read_from_file( trim(filename), mesh_names(i), ugrid_2d )
       global_mesh = global_mesh_type( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
       call global_mesh_collection%add_new_global_mesh( global_mesh )

--- a/infrastructure/unit-test/mesh/mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_mod_test.pf
@@ -815,7 +815,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler_ )
     call ugrid_2d%set_file_handler( file_handler_ )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
     ! Create all the meshes: global and local
     do i=1, size(mesh_names)
@@ -837,7 +837,7 @@ contains
       call global_mesh%clear()
       call local_mesh%clear()
     end do
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! Now all the meshes exist, read in global mesh maps, convert them to local ids

--- a/infrastructure/unit-test/mesh/mesh_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_mod_test.pf
@@ -37,6 +37,9 @@ module mesh_mod_test
                                   partitioner_cubedsphere_serial
   use ugrid_mesh_data_mod,  only: ugrid_mesh_data_type
   use panel_decomposition_mod, only: custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use pfunit
 
@@ -797,6 +800,9 @@ contains
     integer(i_def), parameter :: max_stencil_depth    = 1
     logical(l_def), parameter :: generate_inner_halos = .true.
     logical(l_def), parameter :: enforce_constraints  = .true.
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler_
 
     ! Clear out the global and local mesh collection, as they may contain
     ! unit test meshes - which is not what we want.
@@ -807,9 +813,13 @@ contains
     mesh_collection        = mesh_collection_type()
     partitioner_ptr => partitioner_cubedsphere_serial
 
+    allocate( ncdf_quad_type :: file_handler_ )
+    call ugrid_2d%set_file_handler( file_handler_ )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
     ! Create all the meshes: global and local
     do i=1, size(mesh_names)
-      call ugrid_mesh_data%read_from_file(trim(filename), mesh_names(i))
+      call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
       global_mesh = global_mesh_type( ugrid_mesh_data )
       call ugrid_mesh_data%clear()
       call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -827,6 +837,8 @@ contains
       call global_mesh%clear()
       call local_mesh%clear()
     end do
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler_)) deallocate( file_handler_ )
 
     ! Now all the meshes exist, read in global mesh maps, convert them to local ids
     ! and associate them with the approprate source local mesh

--- a/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
@@ -132,7 +132,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    print, *, trim(filename)
+    print *, trim(filename)
     call ugrid_2d%file_handler_open(trim(filename))
     ! Run through mesh construction process to initialise tiling via
     ! the mesh_type API

--- a/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
@@ -132,13 +132,14 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    print, *, trim(filename)
+    call ugrid_2d%file_handler_open(trim(filename))
     ! Run through mesh construction process to initialise tiling via
     ! the mesh_type API
     call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
      global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )

--- a/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
@@ -19,6 +19,9 @@ module mesh_tiling_mod_test
   use lfric_mpi_mod,              only: global_mpi, &
                                         lfric_comm_type
   use panel_decomposition_mod,    only: custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use pfunit
 
@@ -123,13 +126,21 @@ contains
     procedure(partitioner_interface), pointer :: partitioner_ptr => null()
 
     logical(l_def), parameter :: enforce_constraints = .false.
+    type(ugrid_2d_type) :: ugrid_2d
 
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
     ! Run through mesh construction process to initialise tiling via
     ! the mesh_type API
-    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name )
+    call ugrid_mesh_data%read_from_file( trim(filename), mesh_name, ugrid_2d )
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    global_mesh_id = global_mesh%get_id()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
+     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
     global_mesh_ptr => global_mesh_collection%get_global_mesh( global_mesh_id )
 

--- a/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
+++ b/infrastructure/unit-test/mesh/mesh_tiling_mod_test.pf
@@ -132,7 +132,6 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    print *, trim(filename)
     call ugrid_2d%file_handler_open(trim(filename))
     ! Run through mesh construction process to initialise tiling via
     ! the mesh_type API

--- a/infrastructure/unit-test/mesh/partition_mod_test.pf
+++ b/infrastructure/unit-test/mesh/partition_mod_test.pf
@@ -134,7 +134,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     num_processes = this%context%getNumProcesses()
@@ -160,7 +160,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -361,7 +361,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     num_processes = this%context%getNumProcesses()
@@ -388,7 +388,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -618,7 +618,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     num_processes = this%context%getNumProcesses()
@@ -645,7 +645,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -846,7 +846,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     num_processes = this%context%getNumProcesses()
@@ -873,7 +873,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
@@ -1106,7 +1106,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
 
     xproc = 1
@@ -1122,7 +1122,7 @@ contains
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )

--- a/infrastructure/unit-test/mesh/partition_mod_test.pf
+++ b/infrastructure/unit-test/mesh/partition_mod_test.pf
@@ -132,11 +132,6 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
       case (1)
@@ -157,6 +152,10 @@ contains
     generate_inner_halos = .true.
 
     filename = 'data/mesh_BiP8x8-750x250.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
+
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
@@ -359,11 +358,6 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
       case (1)
@@ -384,6 +378,9 @@ contains
     generate_inner_halos = .true.
 
     filename = 'data/mesh_planar.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
 
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
@@ -616,11 +613,6 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
       case (1)
@@ -641,6 +633,9 @@ contains
     generate_inner_halos = .true.
 
     filename = 'data/mesh_trench_x.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
 
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
@@ -844,11 +839,6 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
       case (1)
@@ -869,6 +859,9 @@ contains
     generate_inner_halos = .true.
 
     filename = 'data/mesh_trench_y.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
 
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
@@ -1104,11 +1097,6 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
-
     xproc = 1
     yproc = 1
     local_rank = this%getProcessRank()
@@ -1119,6 +1107,9 @@ contains
     generate_inner_halos = .true.
 
     filename = 'data/mesh_C4.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()

--- a/infrastructure/unit-test/mesh/partition_mod_test.pf
+++ b/infrastructure/unit-test/mesh/partition_mod_test.pf
@@ -24,6 +24,9 @@ module partition_mod_test
   use reference_element_mod,      only: reference_cube_type
   use ugrid_mesh_data_mod,        only: ugrid_mesh_data_type
   use panel_decomposition_mod,    only: custom_decomposition_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   implicit none
 
@@ -125,6 +128,14 @@ contains
     logical(l_def), parameter :: enforce_constraints = .false.
 
     character(len = str_max_filename) :: filename
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
@@ -146,9 +157,11 @@ contains
     generate_inner_halos = .true.
 
     filename = 'data/mesh_BiP8x8-750x250.nc'
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
     global_mesh_ptr => global_mesh_collection%get_global_mesh( global_mesh_id )
@@ -342,6 +355,14 @@ contains
     logical(l_def), parameter :: enforce_constraints = .false.
 
     character(len = str_max_filename) :: filename
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
@@ -364,9 +385,11 @@ contains
 
     filename = 'data/mesh_planar.nc'
 
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
 
@@ -589,6 +612,14 @@ contains
     logical(l_def), parameter :: enforce_constraints = .false.
 
     character(len = str_max_filename) :: filename
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
@@ -611,9 +642,11 @@ contains
 
     filename = 'data/mesh_trench_x.nc'
 
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
 
@@ -807,6 +840,14 @@ contains
     logical(l_def), parameter :: enforce_constraints =.false.
 
     character(len = str_max_filename) :: filename
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     num_processes = this%context%getNumProcesses()
     select case (num_processes)
@@ -829,9 +870,11 @@ contains
 
     filename = 'data/mesh_trench_y.nc'
 
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
 
@@ -1057,6 +1100,14 @@ contains
     logical(l_def), parameter :: enforce_constraints = .false.
 
     character(len = str_max_filename) :: filename
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
 
     xproc = 1
     yproc = 1
@@ -1068,9 +1119,11 @@ contains
     generate_inner_halos = .true.
 
     filename = 'data/mesh_C4.nc'
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name, ugrid_2d)
     global_mesh = global_mesh_type( ugrid_mesh_data )
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
     global_mesh_id = global_mesh%get_id()
     call global_mesh_collection%add_new_global_mesh( global_mesh )
     global_mesh_ptr => global_mesh_collection%get_global_mesh( global_mesh_id )

--- a/infrastructure/unit-test/mesh/ugrid_mesh_data_mod_test.pf
+++ b/infrastructure/unit-test/mesh/ugrid_mesh_data_mod_test.pf
@@ -108,15 +108,15 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
     !-------------------------------------
     ! Test ugrid_mesh_data object
     !-------------------------------------
     mesh_name_in = 'unit_test'
     filename = 'data/mesh_BiP8x8-750x250.nc'
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
+
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name_in, ugrid_2d)
 
     call ugrid_mesh_data%get_data(                     &
@@ -466,10 +466,6 @@ contains
 
     class(ugrid_file_type), allocatable :: file_handler
 
-    allocate( ncdf_quad_type :: file_handler )
-    call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler_open(trim(filename))
-
     kgo_domain_extents(:,1)  = [ -4.0_r_def, -4.0_r_def]
     kgo_domain_extents(:,2)  = [ 16.0_r_def, -4.0_r_def]
     kgo_domain_extents(:,3)  = [ 16.0_r_def, 16.0_r_def]
@@ -477,6 +473,10 @@ contains
 
     mesh_name_in = 'SQ20'
     filename = 'data/dev_LAM_locals_20-24.nc'
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler_open(trim(filename))
     call ugrid_mesh_data%read_from_file(trim(filename), mesh_name_in, ugrid_2d)
 
     call ugrid_mesh_data%get_data(                     &

--- a/infrastructure/unit-test/mesh/ugrid_mesh_data_mod_test.pf
+++ b/infrastructure/unit-test/mesh/ugrid_mesh_data_mod_test.pf
@@ -13,6 +13,9 @@ module ugrid_mesh_data_mod_test
   use lfric_mpi_mod,       only: global_mpi, &
                                  lfric_comm_type
   use ugrid_mesh_data_mod, only: ugrid_mesh_data_type
+  use ugrid_2d_mod,   only: ugrid_2d_type
+  use ugrid_file_mod, only: ugrid_file_type
+  use ncdf_quad_mod,  only: ncdf_quad_type
 
   use pfunit
 
@@ -101,13 +104,20 @@ contains
 
     character(str_def)      :: coord_units_xy(2)
     character(str_longlong) :: constructor_inputs
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
 
     !-------------------------------------
     ! Test ugrid_mesh_data object
     !-------------------------------------
     mesh_name_in = 'unit_test'
     filename = 'data/mesh_BiP8x8-750x250.nc'
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name_in)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name_in, ugrid_2d)
 
     call ugrid_mesh_data%get_data(                     &
                              mesh_name_out,            &
@@ -187,6 +197,8 @@ contains
     @assertEqual( [128_i_def, 24_i_def, 121_i_def, 120_i_def], edge_on_face_2d(:,64) )
 
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
 
     if ( allocated(target_global_mesh_names) ) deallocate( target_global_mesh_names )
 
@@ -450,6 +462,14 @@ contains
       271,272,273,231,     273,274,275,233,     275,276,277,235,    277,278,279,237, &
       279,280,281,239 ], (/4, kgo_n_faces/) )
 
+    type(ugrid_2d_type) :: ugrid_2d
+
+    class(ugrid_file_type), allocatable :: file_handler
+
+    allocate( ncdf_quad_type :: file_handler )
+    call ugrid_2d%set_file_handler( file_handler )
+    call ugrid_2d%file_handler%file_open(trim(filename))
+
     kgo_domain_extents(:,1)  = [ -4.0_r_def, -4.0_r_def]
     kgo_domain_extents(:,2)  = [ 16.0_r_def, -4.0_r_def]
     kgo_domain_extents(:,3)  = [ 16.0_r_def, 16.0_r_def]
@@ -457,7 +477,7 @@ contains
 
     mesh_name_in = 'SQ20'
     filename = 'data/dev_LAM_locals_20-24.nc'
-    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name_in)
+    call ugrid_mesh_data%read_from_file(trim(filename), mesh_name_in, ugrid_2d)
 
     call ugrid_mesh_data%get_data(                     &
                              mesh_name_out,            &
@@ -561,6 +581,8 @@ contains
     @assertEqual( kgo_edge_on_cell_gid, edge_on_cell_gid )
 
     call ugrid_mesh_data%clear()
+    call ugrid_2d%file_handler%file_close()
+    if (allocated(file_handler)) deallocate( file_handler )
 
   end subroutine test_ugrid_local_mesh_data
 

--- a/infrastructure/unit-test/mesh/ugrid_mesh_data_mod_test.pf
+++ b/infrastructure/unit-test/mesh/ugrid_mesh_data_mod_test.pf
@@ -110,7 +110,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
     !-------------------------------------
     ! Test ugrid_mesh_data object
@@ -197,7 +197,7 @@ contains
     @assertEqual( [128_i_def, 24_i_def, 121_i_def, 120_i_def], edge_on_face_2d(:,64) )
 
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
     if ( allocated(target_global_mesh_names) ) deallocate( target_global_mesh_names )
@@ -468,7 +468,7 @@ contains
 
     allocate( ncdf_quad_type :: file_handler )
     call ugrid_2d%set_file_handler( file_handler )
-    call ugrid_2d%file_handler%file_open(trim(filename))
+    call ugrid_2d%file_handler_open(trim(filename))
 
     kgo_domain_extents(:,1)  = [ -4.0_r_def, -4.0_r_def]
     kgo_domain_extents(:,2)  = [ 16.0_r_def, -4.0_r_def]
@@ -581,7 +581,7 @@ contains
     @assertEqual( kgo_edge_on_cell_gid, edge_on_cell_gid )
 
     call ugrid_mesh_data%clear()
-    call ugrid_2d%file_handler%file_close()
+    call ugrid_2d%file_handler_close()
     if (allocated(file_handler)) deallocate( file_handler )
 
   end subroutine test_ugrid_local_mesh_data


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @andrewcoughtrie 
Code Reviewer: @harry-shepherd 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

This changes delivers a targeted and limited scope refactor of the interaction between the `components/driver/source/driver_mesh_mod.f90` mesh initialisation and the `infrastructure/source/io/ugrid_2d_mod` netCDF interface.

currently each read operation opens the file, reads a snippet of data, then closes the file.
this happens many times on each rank, e.g. 10 times for an `lfric_atm` `C896` rank.
this puts excessive load on parallel file systems and their metadata server provision.
combined with loading from a single mesh file across thousands of ranks, this load becomes unmanageable.

This change alters the internal interface to open the file once per rank, read all required information and close the file.
this reduces the number of file operations by a factor (e.g. factor 10 at `C896`)

this is a stand alone change, but it is intended to work with pre-partitioned meshes to manage load for large runs.


<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - lfric_core - load_mesh_limit_open_calls_per_rank/run3

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [load_mesh_limit_open_calls_per_rank/run3](https://cylchub/services/cylc-review/cycles/mark.hedley/?suite=load_mesh_limit_open_calls_per_rank%2Frun3) |
| Suite User | mark.hedley |
| Workflow Start | 2026-08-10T10:51:47 |
| Groups Run | all |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [mo-marqh/lfric_core@load_mesh_limit_open_calls_per_rank](https://github.com/mo-marqh/lfric_core/tree/load_mesh_limit_open_calls_per_rank) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 433


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
