### PR TITLE
Fixing YAXT index list related memory leaks in generation of redistribution map

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,4 @@
 | ukmo-juan-castillo  | Juan M. Castillo    | Met Office            | 2026-03-24 |
 | mcdalvi          | Mohit Dalvi            | Met Office            | 2026-06-19 |
 | cjohnson-pi      | Christine Johnson      | Met Office            | 2026-06-29 |
+| DrTVockerodtMO   | Terence Vockerodt      | Met Office            | 2026-08-17 |

--- a/infrastructure/source/utilities/halo_comms_mod.F90
+++ b/infrastructure/source/utilities/halo_comms_mod.F90
@@ -837,7 +837,6 @@ function generate_redistribution_map(src_indices, tgt_indices, datatype, xmap) &
   redist = 0
 #else
   type(xt_redist) :: redist
-  type(xt_idxlist) :: src_idxlist, tgt_idxlist
   integer(i_def), allocatable :: src_offsets(:)
   integer(i_def), allocatable :: tgt_offsets(:)
   integer(i_def) :: i
@@ -845,9 +844,6 @@ function generate_redistribution_map(src_indices, tgt_indices, datatype, xmap) &
 
   if( global_mpi%is_comm_set() )then
     ! create decomposition descriptors
-    src_idxlist = xt_idxvec_new( src_indices, size(src_indices) )
-    tgt_idxlist = xt_idxvec_new( tgt_indices, size(tgt_indices) )
-
     allocate(src_offsets( size(src_indices) ))
     allocate(tgt_offsets( size(tgt_indices) ))
 
@@ -864,9 +860,6 @@ function generate_redistribution_map(src_indices, tgt_indices, datatype, xmap) &
 
     deallocate(src_offsets)
     deallocate(tgt_offsets)
-
-    call xt_idxlist_delete(tgt_idxlist)
-    call xt_idxlist_delete(src_idxlist)
   else
     call log_event( &
     'Call to generate_redistribution_map failed. Must initialise mpi first', &

--- a/infrastructure/source/utilities/halo_comms_mod.F90
+++ b/infrastructure/source/utilities/halo_comms_mod.F90
@@ -860,10 +860,13 @@ function generate_redistribution_map(src_indices, tgt_indices, datatype, xmap) &
     end do
 
     datatype_mpi_val = datatype%get_datatype_mpi_val()
-    redist = xt_redist_p2p_off_new(xmap, src_offsets,tgt_offsets, datatype_mpi_val)
+    redist = xt_redist_p2p_off_new(xmap, src_offsets, tgt_offsets, datatype_mpi_val)
 
     deallocate(src_offsets)
     deallocate(tgt_offsets)
+
+    call xt_idxlist_delete(tgt_idxlist)
+    call xt_idxlist_delete(src_idxlist)
   else
     call log_event( &
     'Call to generate_redistribution_map failed. Must initialise mpi first', &
@@ -903,7 +906,7 @@ function generate_exchange_map(src_indices, tgt_indices) result(xmap)
     ! generate exchange map
     comm = global_mpi%get_comm()
     xmap = xt_xmap_dist_dir_new( src_idxlist, tgt_idxlist, &
-                                    comm%get_comm_mpi_val() )
+                                 comm%get_comm_mpi_val() )
     call xt_idxlist_delete(tgt_idxlist)
     call xt_idxlist_delete(src_idxlist)
   else


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) --> @mo-lormi 
Code Reviewer: @andrewcoughtrie <!-- CR id, filled by SSD/CCD (e.g. @octocat) -->

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

The locally scoped source and target index lists used to generate the redistribution map are allocated but never freed. YAXT has routines to free the memory of its index lists which are used in the same file in the generation of the exchange maps. I have replicated this for the redistribution maps.

EDIT: These index lists actually do not appear to be doing anything in this routine and have been removed instead.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->
- fixes #449 

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [ ] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - lfric_core - mem_leak_idxlists/run2

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [mem_leak_idxlists/run2](https://cylchub/services/cylc-review/cycles/terence.vockerodt/?suite=mem_leak_idxlists%2Frun2) |
| Suite User | terence.vockerodt |
| Workflow Start | 2026-08-18T09:37:19 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [DrTVockerodtMO/lfric_core@mem_leak_idxlists](https://github.com/DrTVockerodtMO/lfric_core/tree/mem_leak_idxlists) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 433

# Test Suite Results - lfric_apps - linked_mem_leak_idxlists/run2

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [linked_mem_leak_idxlists/run2](https://cylchub/services/cylc-review/cycles/terence.vockerodt/?suite=linked_mem_leak_idxlists%2Frun2) |
| Suite User | terence.vockerodt |
| Workflow Start | 2026-08-18T10:49:26 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.07.1](https://github.com/MetOffice/casim/tree/2026.07.1) | True |
| jules | [MetOffice/jules@2026.07.1](https://github.com/MetOffice/jules/tree/2026.07.1) | True |
| lfric_apps | [DrTVockerodtMO/lfric_apps@linked_mem_leak_idxlists](https://github.com/DrTVockerodtMO/lfric_apps/tree/linked_mem_leak_idxlists) | False |
| lfric_core | [DrTVockerodtMO/lfric_core@mem_leak_idxlists](https://github.com/DrTVockerodtMO/lfric_core/tree/mem_leak_idxlists) | True |
| moci | [MetOffice/moci@2026.07.1](https://github.com/MetOffice/moci/tree/2026.07.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@77a5166](https://github.com/MetOffice/SimSys_Scripts/tree/77a5166) | True |
| socrates | [MetOffice/socrates@2026.07.1](https://github.com/MetOffice/socrates/tree/2026.07.1) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.07.1](https://github.com/MetOffice/socrates-spectral/tree/2026.07.1) | True |
| ukca | [MetOffice/ukca@9fc2b6d](https://github.com/MetOffice/ukca/tree/9fc2b6d) | True |

## Task Information
:white_check_mark: succeeded tasks - 1218

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [TCD Team](mailto:ToolsCollabDevTeam@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] CLA compliance has been confirmed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
