### PR TITLE
Refactor code implementing initial chi transform with respect to North Pole and Schmit stretching

### DIFF
--- a/components/driver/source/driver_coordinates_mod.F90
+++ b/components/driver/source/driver_coordinates_mod.F90
@@ -170,11 +170,6 @@ contains
     local_mesh => mesh%get_local_mesh()
     panel_ncells = local_mesh%get_ncells_global_mesh()/local_mesh%get_num_panels_global_mesh()
 
-    ! Stretch factor and rotation valid on a spherical surface.
-    to_rotate = get_to_rotate()
-    stretch_factor = get_stretch_factor()
-    inverse_rot_matrix = get_inverse_mesh_rotation_matrix()
-
     panel_id_proxy%data = 1.0_r_def
 
     if ( coord_system == coord_system_xyz .or. &
@@ -219,6 +214,11 @@ contains
     else if ( geometry == geometry_spherical .and. &
               topology /= topology_fully_periodic ) then
 
+      ! Allow for Rotated/Schmit stretched meshes
+      to_rotate = get_to_rotate()
+      stretch_factor = get_stretch_factor()
+      inverse_rot_matrix = get_inverse_mesh_rotation_matrix()
+
       do cell = 1,chi_proxy(1)%vspace%get_ncell()
 
         call calc_panel_id( nlayers_pid,         &
@@ -253,6 +253,11 @@ contains
 
     else if ( geometry == geometry_spherical .and. &
               topology == topology_fully_periodic ) then
+
+      ! Allow for Rotated/Schmit stretched meshes
+      to_rotate = get_to_rotate()
+      stretch_factor = get_stretch_factor()
+      inverse_rot_matrix = get_inverse_mesh_rotation_matrix()
 
       do cell = 1,chi_proxy(1)%vspace%get_ncell()
 

--- a/components/driver/source/driver_coordinates_mod.F90
+++ b/components/driver/source/driver_coordinates_mod.F90
@@ -170,21 +170,31 @@ contains
     local_mesh => mesh%get_local_mesh()
     panel_ncells = local_mesh%get_ncells_global_mesh()/local_mesh%get_num_panels_global_mesh()
 
-    ! Get *inverse* rotation matrix and stretching factor here
-    stretch_factor = get_stretch_factor()
-    inverse_rot_matrix = get_inverse_mesh_rotation_matrix()
-    to_rotate = get_to_rotate()
+    ! Stretch factor is only valid if on a spherical surface.
+!    if (geometry == geometry_spherical) then
 
-    ! Throw an error if stretching factor is not 1 and not on cubed-sphere
-    if ( abs(stretch_factor - 1.0_r_def) > eps .and. .not.                     &
-         (geometry == geometry_spherical .and.                                 &
-          topology == topology_fully_periodic) ) then
-      call log_event(                                                          &
-        'driver_coordinates: Cannot determine coordinates if Schmidt ' //      &
-        'stretching factor is not 1 and mesh is not cubed-sphere',             &
-        log_level_error                                                        &
-      )
-    end if
+      to_rotate = get_to_rotate()
+      stretch_factor = get_stretch_factor()
+      inverse_rot_matrix = get_inverse_mesh_rotation_matrix()
+
+!     if (topology == topology_fully_periodic) ) then
+
+        ! Get *inverse* rotation matrix and stretching factor here
+
+
+
+!!$    ! Throw an error if stretching factor is not 1 and not on cubed-sphere
+!!$    if ( abs(stretch_factor - 1.0_r_def) > eps .and. .not.                     &
+!!$         (geometry == geometry_spherical .and.                                 &
+!!$          topology == topology_fully_periodic) ) then
+!!$      call log_event(                                                          &
+!!$        'driver_coordinates: Cannot determine coordinates if Schmidt ' //      &
+!!$        'stretching factor is not 1 and mesh is not cubed-sphere',             &
+!!$        log_level_error                                                        &
+!!$      )
+!!$    end if
+
+!    end if
 
     panel_id_proxy%data = 1.0_r_def
 

--- a/components/driver/source/driver_coordinates_mod.F90
+++ b/components/driver/source/driver_coordinates_mod.F90
@@ -170,31 +170,10 @@ contains
     local_mesh => mesh%get_local_mesh()
     panel_ncells = local_mesh%get_ncells_global_mesh()/local_mesh%get_num_panels_global_mesh()
 
-    ! Stretch factor is only valid if on a spherical surface.
-!    if (geometry == geometry_spherical) then
-
-      to_rotate = get_to_rotate()
-      stretch_factor = get_stretch_factor()
-      inverse_rot_matrix = get_inverse_mesh_rotation_matrix()
-
-!     if (topology == topology_fully_periodic) ) then
-
-        ! Get *inverse* rotation matrix and stretching factor here
-
-
-
-!!$    ! Throw an error if stretching factor is not 1 and not on cubed-sphere
-!!$    if ( abs(stretch_factor - 1.0_r_def) > eps .and. .not.                     &
-!!$         (geometry == geometry_spherical .and.                                 &
-!!$          topology == topology_fully_periodic) ) then
-!!$      call log_event(                                                          &
-!!$        'driver_coordinates: Cannot determine coordinates if Schmidt ' //      &
-!!$        'stretching factor is not 1 and mesh is not cubed-sphere',             &
-!!$        log_level_error                                                        &
-!!$      )
-!!$    end if
-
-!    end if
+    ! Stretch factor and rotation valid on a spherical surface.
+    to_rotate = get_to_rotate()
+    stretch_factor = get_stretch_factor()
+    inverse_rot_matrix = get_inverse_mesh_rotation_matrix()
 
     panel_id_proxy%data = 1.0_r_def
 

--- a/components/driver/source/driver_fem_mod.f90
+++ b/components/driver/source/driver_fem_mod.f90
@@ -112,6 +112,14 @@ contains
     all_mesh_names = mesh_collection%get_mesh_names()
 
     prime_mesh_name = cmdi
+
+    ! Set initial chi transformation to match input meshes.
+    ! Assumption:
+    ! All [lat,lon] spherical surface meshes in the mesh collection will have
+    ! been rotated/stretched to the same degree. So choose the principle mesh
+    ! in the configuration that the application is to run on. Where this is
+    ! not set, use the 1st mesh in the collection.
+    !
     if (config%namelist_exists('base_mesh')) then
       prime_mesh_name = config%base_mesh%prime_mesh_name()
       mesh => mesh_collection%get_mesh(prime_mesh_name)
@@ -127,8 +135,8 @@ contains
       null_island = local_mesh%get_null_island()
       equatorial_latitude = local_mesh%get_equatorial_latitude()
 
-      call init_chi_transforms( north_pole, null_island, &
-                                equatorial_latitude )
+      call init_chi_transforms( north_pole, null_island, equatorial_latitude )
+
     end if
 
     call chi_inventory%initialise(name="chi", table_len=size(all_mesh_names))

--- a/components/driver/source/driver_fem_mod.f90
+++ b/components/driver/source/driver_fem_mod.f90
@@ -104,35 +104,34 @@ contains
     coord_order_nonprime = config%finite_element%coord_order_nonprime()
     scaled_radius        = config%planet%scaled_radius()
 
-    ! ======================================================================== !
-    ! Initialise coordinates
-    ! ======================================================================== !
-
-    ! To loop through mesh collection, get all mesh names
-    ! Then get mesh from collection using these names
     n_meshes       = mesh_collection%n_meshes()
     all_mesh_names = mesh_collection%get_mesh_names()
 
-    ! Set initial chi transformation to match input meshes.
-    ! Assumption:
-    ! All [lat,lon] spherical surface meshes in the mesh collection will have
-    ! been rotated/stretched to the same degree. So choose the principle mesh
-    ! in the configuration that the application is to run on. Where this is
-    ! not set, use the 1st mesh in the collection.
-    !
-!    if (config%namelist_exists('base_mesh')) then
-!      prime_mesh_name = config%base_mesh%prime_mesh_name()
-!      mesh => mesh_collection%get_mesh(prime_mesh_name)
-!    else
-!print*, 'n_meshes=', mesh_collection%n_meshes()
-!print*, 'all_mesh_names=', all_mesh_names
-!     mesh => mesh_collection%get_mesh(all_mesh_names(1))
-!    end if
-!     if (size(all_mesh_names) > 0) then
-!       mesh => mesh_collection%get_mesh(all_mesh_names(1))
-!     else
-!call log_event('no meshes', log_level_error)
-!     end if
+    ! ======================================================================== !
+    ! Initialise coordinates
+    ! ======================================================================== !
+    prime_mesh_name = cmdi
+    if (config%namelist_exists('base_mesh')) then
+      prime_mesh_name = config%base_mesh%prime_mesh_name()
+    end if
+
+    if (trim(prime_mesh_name) == trim(cmdi)) then
+      mesh => mesh_collection%get_mesh(all_mesh_names(1))
+    else
+      mesh => mesh_collection%get_mesh(prime_mesh_name)
+    end if
+
+    if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
+
+      ! Initialise any coordinate transformations
+      local_mesh => mesh%get_local_mesh()
+      north_pole  = local_mesh%get_north_pole()
+      null_island = local_mesh%get_null_island()
+      equatorial_latitude = local_mesh%get_equatorial_latitude()
+
+      call init_chi_transforms( north_pole, null_island, equatorial_latitude )
+
+    end if
 
     call chi_inventory%initialise(name="chi", table_len=n_meshes)
     call panel_id_inventory%initialise(name="panel_id", table_len=n_meshes)
@@ -145,18 +144,6 @@ contains
 
       mesh => mesh_collection%get_mesh(all_mesh_names(i))
       mesh_name = mesh%get_mesh_name()
-
-      if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
-
-        ! Initialise any coordinate transformations
-        local_mesh => mesh%get_local_mesh()
-        north_pole  = local_mesh%get_north_pole()
-        null_island = local_mesh%get_null_island()
-        equatorial_latitude = local_mesh%get_equatorial_latitude()
-
-        call init_chi_transforms( north_pole, null_island, equatorial_latitude )
-
-      end if
 
       if (mesh%is_geometry_spherical()) then
         geometry = geometry_spherical

--- a/components/driver/source/driver_fem_mod.f90
+++ b/components/driver/source/driver_fem_mod.f90
@@ -97,11 +97,6 @@ contains
 
     nullify(mesh, twod_mesh, local_mesh, fs)
 
-    prime_mesh_name = cmdi
-    if (config%namelist_exists('base_mesh')) then
-      prime_mesh_name = config%base_mesh%prime_mesh_name()
-    end if
-
     coord_system         = config%finite_element%coord_system()
     coord_order          = config%finite_element%coord_order()
     coord_space          = config%finite_element%coord_space()
@@ -115,6 +110,26 @@ contains
     ! To loop through mesh collection, get all mesh names
     ! Then get mesh from collection using these names
     all_mesh_names = mesh_collection%get_mesh_names()
+
+    prime_mesh_name = cmdi
+    if (config%namelist_exists('base_mesh')) then
+      prime_mesh_name = config%base_mesh%prime_mesh_name()
+      mesh => mesh_collection%get_mesh(prime_mesh_name)
+    else
+      mesh => mesh_collection%get_mesh(all_mesh_names(1))
+    end if
+
+    if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
+
+      ! Initialise any coordinate transformations
+      local_mesh => mesh%get_local_mesh()
+      north_pole  = local_mesh%get_north_pole()
+      null_island = local_mesh%get_null_island()
+      equatorial_latitude = local_mesh%get_equatorial_latitude()
+
+      call init_chi_transforms( north_pole, null_island, &
+                                equatorial_latitude )
+    end if
 
     call chi_inventory%initialise(name="chi", table_len=size(all_mesh_names))
     call panel_id_inventory%initialise(name="panel_id", &
@@ -139,18 +154,6 @@ contains
         topology = topology_fully_periodic
       else
         topology = topology_non_periodic
-      end if
-
-      if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
-
-        ! Initialise coordinate transformations
-        local_mesh => mesh%get_local_mesh()
-        north_pole  = local_mesh%get_north_pole()
-        null_island = local_mesh%get_null_island()
-        equatorial_latitude = local_mesh%get_equatorial_latitude()
-
-        call init_chi_transforms( north_pole, null_island, &
-                                  equatorial_latitude)
       end if
 
       ! Only create coordinates for 3D meshes

--- a/components/driver/source/driver_fem_mod.f90
+++ b/components/driver/source/driver_fem_mod.f90
@@ -43,11 +43,6 @@ module driver_fem_mod
                                        coord_space_W0,   &
                                        coord_space_Wchi, &
                                        coord_space_Wtheta
-!use sci_chi_transform_mod, only: get_mesh_rotation_matrix, &
-!      get_inverse_mesh_rotation_matrix, &
-!get_stretch_factor, &
-!get_to_rotate, &
-!get_to_stretch
 
   implicit none
 
@@ -146,13 +141,6 @@ contains
         topology = topology_non_periodic
       end if
 
-!      print*,'Spherical surface? ',  mesh%is_geometry_spherical()
-!      print*,'Periodic topology?',   mesh%is_topology_periodic()
-!      print*,'Coord_Sys_ll?',        mesh%is_coord_sys_ll()
-
-!     if ( (geometry == geometry_spherical) .and. &
-!          (topology == topology_fully_periodic) ) then
-
       if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
 
         ! Initialise coordinate transformations
@@ -164,12 +152,6 @@ contains
         call init_chi_transforms( north_pole, null_island, &
                                   equatorial_latitude)
       end if
-
-!      print*,'Rotation matrix ',  get_mesh_rotation_matrix()
-!      print*,'Inverse Rotation matrix ', get_inverse_mesh_rotation_matrix()
-!      print*,'SF ', get_stretch_factor()
-!      print*,'Rotate? ', get_to_rotate()
-!      print*,'Stretch? ', get_to_stretch()
 
       ! Only create coordinates for 3D meshes
       if (mesh%get_extrusion_id() /= twod) then

--- a/components/driver/source/driver_fem_mod.f90
+++ b/components/driver/source/driver_fem_mod.f90
@@ -29,7 +29,9 @@ module driver_fem_mod
   ! Object types
   use config_mod, only: config_type
   use field_mod,  only: field_type
+
   use mesh_mod,   only: mesh_type
+  use local_mesh_mod,   only: local_mesh_type
   use inventory_by_mesh_mod, only: inventory_by_mesh_type
 
   ! Configuration modules
@@ -41,6 +43,11 @@ module driver_fem_mod
                                        coord_space_W0,   &
                                        coord_space_Wchi, &
                                        coord_space_Wtheta
+use sci_chi_transform_mod, only: get_mesh_rotation_matrix, &
+      get_inverse_mesh_rotation_matrix, &
+get_stretch_factor, &
+get_to_rotate, &
+get_to_stretch
 
   implicit none
 
@@ -84,10 +91,16 @@ contains
     integer(i_def)     :: coord_space, coord_order, coord_order_nonprime
     real(r_def)        :: scaled_radius
 
+    real(r_def) :: north_pole(2)
+    real(r_def) :: null_island(2)
+    real(r_def) :: equatorial_latitude
+
+    type(local_mesh_type), pointer :: local_mesh
+
     call log_event( 'FEM specifics: creating function spaces...', &
                     log_level_info )
 
-    nullify(mesh, twod_mesh, fs)
+    nullify(mesh, twod_mesh, local_mesh, fs)
 
     prime_mesh_name = cmdi
     if (config%namelist_exists('base_mesh')) then
@@ -133,9 +146,30 @@ contains
         topology = topology_non_periodic
       end if
 
-      ! Initialise coordinate transformations
-      call init_chi_transforms( geometry, topology, &
-                                mesh_collection=mesh_collection )
+      print*,'Spherical surface? ',  mesh%is_geometry_spherical()
+      print*,'Periodic topology?',   mesh%is_topology_periodic()
+      print*,'Coord_Sys_ll?',        mesh%is_coord_sys_ll()
+
+!     if ( (geometry == geometry_spherical) .and. &
+!          (topology == topology_fully_periodic) ) then
+
+      if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
+
+        ! Initialise coordinate transformations
+        local_mesh => mesh%get_local_mesh()
+        north_pole  = local_mesh%get_north_pole()
+        null_island = local_mesh%get_null_island()
+        equatorial_latitude = local_mesh%get_equatorial_latitude()
+
+        call init_chi_transforms( north_pole, null_island, &
+                                  equatorial_latitude)
+      end if
+
+      print*,'Rotation matrix ',  get_mesh_rotation_matrix()
+      print*,'Inverse Rotation matrix ', get_inverse_mesh_rotation_matrix()
+      print*,'SF ', get_stretch_factor()
+      print*,'Rotate? ', get_to_rotate()
+      print*,'Stretch? ', get_to_stretch()
 
       ! Only create coordinates for 3D meshes
       if (mesh%get_extrusion_id() /= twod) then

--- a/components/driver/source/driver_fem_mod.f90
+++ b/components/driver/source/driver_fem_mod.f90
@@ -84,6 +84,7 @@ contains
     character(str_def) :: mesh_name, prime_mesh_name
     integer(i_def)     :: geometry, topology, coord_system
     integer(i_def)     :: coord_space, coord_order, coord_order_nonprime
+    integer(i_def)     :: n_meshes
     real(r_def)        :: scaled_radius
 
     real(r_def) :: north_pole(2)
@@ -109,9 +110,8 @@ contains
 
     ! To loop through mesh collection, get all mesh names
     ! Then get mesh from collection using these names
+    n_meshes       = mesh_collection%n_meshes()
     all_mesh_names = mesh_collection%get_mesh_names()
-
-    prime_mesh_name = cmdi
 
     ! Set initial chi transformation to match input meshes.
     ! Assumption:
@@ -120,37 +120,43 @@ contains
     ! in the configuration that the application is to run on. Where this is
     ! not set, use the 1st mesh in the collection.
     !
-    if (config%namelist_exists('base_mesh')) then
-      prime_mesh_name = config%base_mesh%prime_mesh_name()
-      mesh => mesh_collection%get_mesh(prime_mesh_name)
-    else
-      mesh => mesh_collection%get_mesh(all_mesh_names(1))
-    end if
+!    if (config%namelist_exists('base_mesh')) then
+!      prime_mesh_name = config%base_mesh%prime_mesh_name()
+!      mesh => mesh_collection%get_mesh(prime_mesh_name)
+!    else
+!print*, 'n_meshes=', mesh_collection%n_meshes()
+!print*, 'all_mesh_names=', all_mesh_names
+!     mesh => mesh_collection%get_mesh(all_mesh_names(1))
+!    end if
+!     if (size(all_mesh_names) > 0) then
+!       mesh => mesh_collection%get_mesh(all_mesh_names(1))
+!     else
+!call log_event('no meshes', log_level_error)
+!     end if
 
-    if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
-
-      ! Initialise any coordinate transformations
-      local_mesh => mesh%get_local_mesh()
-      north_pole  = local_mesh%get_north_pole()
-      null_island = local_mesh%get_null_island()
-      equatorial_latitude = local_mesh%get_equatorial_latitude()
-
-      call init_chi_transforms( north_pole, null_island, equatorial_latitude )
-
-    end if
-
-    call chi_inventory%initialise(name="chi", table_len=size(all_mesh_names))
-    call panel_id_inventory%initialise(name="panel_id", &
-                                       table_len=size(all_mesh_names))
+    call chi_inventory%initialise(name="chi", table_len=n_meshes)
+    call panel_id_inventory%initialise(name="panel_id", table_len=n_meshes)
 
     ! ======================================================================== !
     ! Loop through all 3D meshes
     ! ======================================================================== !
 
-    do i = 1, size(all_mesh_names)
+    do i=1, n_meshes
 
       mesh => mesh_collection%get_mesh(all_mesh_names(i))
       mesh_name = mesh%get_mesh_name()
+
+      if ( mesh%is_geometry_spherical() .and. mesh%is_coord_sys_ll() ) then
+
+        ! Initialise any coordinate transformations
+        local_mesh => mesh%get_local_mesh()
+        north_pole  = local_mesh%get_north_pole()
+        null_island = local_mesh%get_null_island()
+        equatorial_latitude = local_mesh%get_equatorial_latitude()
+
+        call init_chi_transforms( north_pole, null_island, equatorial_latitude )
+
+      end if
 
       if (mesh%is_geometry_spherical()) then
         geometry = geometry_spherical

--- a/components/driver/source/driver_fem_mod.f90
+++ b/components/driver/source/driver_fem_mod.f90
@@ -43,11 +43,11 @@ module driver_fem_mod
                                        coord_space_W0,   &
                                        coord_space_Wchi, &
                                        coord_space_Wtheta
-use sci_chi_transform_mod, only: get_mesh_rotation_matrix, &
-      get_inverse_mesh_rotation_matrix, &
-get_stretch_factor, &
-get_to_rotate, &
-get_to_stretch
+!use sci_chi_transform_mod, only: get_mesh_rotation_matrix, &
+!      get_inverse_mesh_rotation_matrix, &
+!get_stretch_factor, &
+!get_to_rotate, &
+!get_to_stretch
 
   implicit none
 
@@ -146,9 +146,9 @@ contains
         topology = topology_non_periodic
       end if
 
-      print*,'Spherical surface? ',  mesh%is_geometry_spherical()
-      print*,'Periodic topology?',   mesh%is_topology_periodic()
-      print*,'Coord_Sys_ll?',        mesh%is_coord_sys_ll()
+!      print*,'Spherical surface? ',  mesh%is_geometry_spherical()
+!      print*,'Periodic topology?',   mesh%is_topology_periodic()
+!      print*,'Coord_Sys_ll?',        mesh%is_coord_sys_ll()
 
 !     if ( (geometry == geometry_spherical) .and. &
 !          (topology == topology_fully_periodic) ) then
@@ -165,11 +165,11 @@ contains
                                   equatorial_latitude)
       end if
 
-      print*,'Rotation matrix ',  get_mesh_rotation_matrix()
-      print*,'Inverse Rotation matrix ', get_inverse_mesh_rotation_matrix()
-      print*,'SF ', get_stretch_factor()
-      print*,'Rotate? ', get_to_rotate()
-      print*,'Stretch? ', get_to_stretch()
+!      print*,'Rotation matrix ',  get_mesh_rotation_matrix()
+!      print*,'Inverse Rotation matrix ', get_inverse_mesh_rotation_matrix()
+!      print*,'SF ', get_stretch_factor()
+!      print*,'Rotate? ', get_to_rotate()
+!      print*,'Stretch? ', get_to_stretch()
 
       ! Only create coordinates for 3D meshes
       if (mesh%get_extrusion_id() /= twod) then

--- a/components/science/source/kernel/geometry/sci_chi_transform_mod.F90
+++ b/components/science/source/kernel/geometry/sci_chi_transform_mod.F90
@@ -24,6 +24,7 @@ use coord_transform_mod,       only : alphabetar2xyz,          &
                                       schmidt_transform_xyz,   &
                                       inverse_schmidt_transform_xyz
 use log_mod,                   only : log_event,               &
+                                      log_level,               &
                                       log_scratch_space,       &
                                       LOG_LEVEL_ERROR,         &
                                       LOG_LEVEL_DEBUG,         &
@@ -45,11 +46,15 @@ private
 ! Private matrices or values that need computing once
 ! ---------------------------------------------------------------------------- !
 
-real(kind=r_def)    :: chi2xyz_rot_mat(3,3)
-real(kind=r_def)    :: xyz2chi_rot_mat(3,3)
-real(kind=r_def)    :: stretch_factor
-logical(kind=l_def) :: to_rotate
-logical(kind=l_def) :: to_stretch
+real(kind=r_def)    :: chi2xyz_rot_mat(3,3) = 0.0_r_def
+real(kind=r_def)    :: xyz2chi_rot_mat(3,3) = 0.0_r_def
+real(kind=r_def)    :: stretch_factor = 1.0_r_def
+logical(kind=l_def) :: to_rotate = .false.
+logical(kind=l_def) :: to_stretch = .false.
+
+real(r_def) ::  north_pole(2)  = [0.0_r_def, PI/2.0_r_def]
+real(r_def) ::  null_island(2) = [0.0_r_def, 0.0_r_def]
+real(r_def) ::  equator_latitude = 0.0_r_def
 
 ! ---------------------------------------------------------------------------- !
 ! Public subroutines
@@ -89,120 +94,46 @@ contains
 !!                               argument, and ideally should only be used for
 !!                               unit-testing.
 !------------------------------------------------------------------------------
-subroutine init_chi_transforms( geometry, topology, &
-                                mesh_collection,    &
-                                north_pole_arg,     &
-                                equator_lat_arg )
-
-  use local_mesh_mod,      only: local_mesh_type
-  use mesh_collection_mod, only: mesh_collection_type
-  use mesh_mod,            only: mesh_type
+subroutine init_chi_transforms( mesh_north_pole,  &
+                                mesh_null_island, &
+                                mesh_equator_latitude )
 
   implicit none
 
-  integer(i_def), intent(in) :: geometry
-  integer(i_def), intent(in) :: topology
+  real(r_def), intent(in) :: mesh_north_pole(2)
+  real(r_def), intent(in) :: mesh_null_island(2)
+  real(r_def), intent(in) :: mesh_equator_latitude
 
-  type(mesh_collection_type), optional, intent(in) :: mesh_collection
-  real(kind=r_def),           optional, intent(in) :: north_pole_arg(2)
-  real(kind=r_def),           optional, intent(in) :: equator_lat_arg
-
-  type(mesh_type),         pointer :: mesh
-  type(local_mesh_type),   pointer :: local_mesh
-  character(str_def),  allocatable :: all_mesh_names(:)
-
-  real(kind=r_def) :: north_pole(2)
-  real(kind=r_def) :: null_island(2)
-  real(kind=r_def) :: equatorial_latitude
-
-  ! -------------------------------------------------------------------------- !
-  ! Extract stretching and rotation information from mesh
-  ! -------------------------------------------------------------------------- !
-
-  ! Begin by assuming no stretching and no rotation
-  to_stretch = .false.
-  to_rotate = .false.
-  north_pole(1) = PI
-  north_pole(2) = PI/2.0_r_def
-  null_island(1) = 0.0_r_def
-  null_island(2) = 0.0_r_def
-  equatorial_latitude = 0.0_r_def
-
-  if ( present(mesh_collection) .and.                                          &
-       (present(equator_lat_arg) .or. present(north_pole_arg)) ) then
-    call log_event(                                                            &
-      'init_chi_transform: mesh_compatible argument cannot be passed with ' // &
-      'another argument', LOG_LEVEL_ERROR                                      &
-    )
+  ! Update North Pole
+  if ( (abs(mesh_north_pole(1) - rmdi) > EPS) .and. &
+       (abs(mesh_north_pole(2) - rmdi) > EPS) ) then
+    north_pole(:) = mesh_north_pole(:)
   end if
 
-  if (present(mesh_collection)) then
-    ! NB:
-    ! At this stage, we will assume that the stretching and rotation are the same
-    ! for all meshes. If they weren't, we would need to extract a different factor
-    ! and different rotation matrix for each mesh. The chi2*** transforms would
-    ! also need to take mesh_id as an argument, which would be a major API change
-    ! since it would need passing through each kernel.
-    ! Therefore, extract first mesh from collection ...
-    all_mesh_names = mesh_collection%get_mesh_names()
-    if (SIZE(all_mesh_names) > 0) then
-      mesh => mesh_collection%get_mesh(all_mesh_names(1))
-    else
-      call log_event(                                                          &
-        'init_chi_transform: unable to determine mesh rotation and ' //        &
-        'stretching because there are no meshes!', LOG_LEVEL_ERROR             &
-      )
-    end if
+  ! Update Null Island
+  if ( (abs(mesh_null_island(1) - rmdi) > EPS) .and. &
+       (abs(mesh_null_island(2) - rmdi) > EPS) ) then
+    null_island(:) = mesh_null_island(:)
+  end if
 
-    ! Extract rotation and stretching information from global mesh
-    local_mesh => mesh%get_local_mesh()
-    north_pole = local_mesh%get_north_pole()
-    null_island = local_mesh%get_null_island()
-    equatorial_latitude = local_mesh%get_equatorial_latitude()
+  if ( abs(mesh_equator_latitude - rmdi) > EPS ) then
+    equator_latitude = mesh_equator_latitude
+  end if
 
-    ! If any variables are unset, set them to defaults here --------------------
-    if ( abs(north_pole(1) - rmdi) < EPS                                       &
-         .or. abs(north_pole(2) - rmdi) < EPS ) then
-      north_pole(1) = 0.0_r_def
-      north_pole(2) = PI/2.0_r_def
-      call log_event(                                                          &
-        'Mesh North Pole not set, so using (lon=0, lat=pi/2) as default',      &
-         LOG_LEVEL_WARNING                                                     &
-      )
-    end if
-    if ( abs(null_island(1) - rmdi) < EPS                                      &
-         .or. abs(null_island(2) - rmdi) < EPS ) then
-      null_island(1) = 0.0_r_def
-      null_island(2) = 0.0_r_def
-      call log_event(                                                          &
-        'Mesh Null Island not set, so using (lon=0, lat=0) as default',        &
-         LOG_LEVEL_WARNING                                                     &
-      )
-    end if
-    if ( abs(equatorial_latitude - rmdi) < EPS .or.                            &
-         geometry == geometry_planar .or. topology /= topology_fully_periodic ) then
-      equatorial_latitude = 0.0_r_def
-      call log_event(                                                          &
-        'Equatorial latitude for mesh not set, so using 0.0 as default',       &
-         LOG_LEVEL_WARNING                                                     &
-      )
-    end if
-  end if ! present(mesh_collection)
+  ! Determine degrees of stretching / rotation.
+  to_stretch = abs(equator_latitude) > EPS
 
-  if (present(north_pole_arg)) north_pole = north_pole_arg
-  if (present(equator_lat_arg)) equatorial_latitude = equator_lat_arg
+print*, 'North Pole ', abs(north_pole(2))
+print*, 'Null island(1) ', abs(null_island(1))
+print*, 'Null island(2) ', abs(null_island(2))
 
-
-  ! Now that parameters have been read in, determine if stretching or rotation
-  ! are actually happening
-  to_stretch = abs(equatorial_latitude) > EPS
-  ! It's probably safer to check both the null island and the north pole here
   to_rotate = ( abs(north_pole(2) - PI/2.0_r_def) > EPS                        &
                 .or. abs(null_island(1)) > EPS .or. abs(null_island(2)) > EPS )
+print*, 'To rotate?', to_rotate
 
   ! Compute Schmidt stretch factor ---------------------------------------------
-  stretch_factor = sqrt( (1.0_r_def - sin(equatorial_latitude))                &
-                         / (1.0_r_def + sin(equatorial_latitude)) )
+  stretch_factor = sqrt( (1.0_r_def - sin(equator_latitude))                &
+                         / (1.0_r_def + sin(equator_latitude)) )
 
   ! Compute rotation matrix ----------------------------------------------------
   chi2xyz_rot_mat = mesh_rotation_matrix(north_pole)
@@ -210,13 +141,19 @@ subroutine init_chi_transforms( geometry, topology, &
   ! Compute inverse rotation matrix --------------------------------------------
   xyz2chi_rot_mat = matrix_invert_3x3(chi2xyz_rot_mat)
 
-  write(log_scratch_space,'(A,L6,A,2E16.8)')                                   &
-    'Mesh rotation: ', to_rotate, ' north pole: ', north_pole(1), north_pole(2)
-  call log_event(log_scratch_space, LOG_LEVEL_DEBUG)
-  write(log_scratch_space,'(A,L6,A,E16.8,A,E16.8)')                            &
-    'Mesh stretching: ', to_stretch, ' stretching factor: ', stretch_factor,   &
-    '   latitude of equator: ', equatorial_latitude
-  call log_event(log_scratch_space, LOG_LEVEL_DEBUG)
+  if (log_level() == log_level_debug) then
+    write(log_scratch_space,'(A,E12.5)') &
+        'Stretching to equator latitude = ', equator_latitude
+    call log_event(log_scratch_space, log_level_debug)
+
+    write(log_scratch_space,'(A,2E12.5)') &
+        'Rotating to north pole = ', north_pole
+    call log_event(log_scratch_space, log_level_debug)
+
+    write(log_scratch_space,'(A,2E12.5)') &
+        'Rotating to Null island = ', null_island
+    call log_event(log_scratch_space, log_level_debug)
+  end if
 
 end subroutine init_chi_transforms
 
@@ -229,9 +166,13 @@ subroutine final_chi_transforms()
 
   to_stretch = .false.
   to_rotate = .false.
-  stretch_factor = rmdi
+  stretch_factor = 1.0_r_def
   chi2xyz_rot_mat(:,:) = 0.0_r_def
   xyz2chi_rot_mat(:,:) = 0.0_r_def
+
+  north_pole  = [0.0_r_def, PI/2.0_r_def]
+  null_island = [0.0_r_def, 0.0_r_def]
+  equator_latitude = 0.0_r_def
 
 end subroutine final_chi_transforms
 

--- a/components/science/source/kernel/geometry/sci_chi_transform_mod.F90
+++ b/components/science/source/kernel/geometry/sci_chi_transform_mod.F90
@@ -79,20 +79,11 @@ contains
 !------------------------------------------------------------------------------
 !> @brief  Initialise the coordinate transform information
 !!
-!> @param[in] geometry           Mesh geometry enumeration value
-!> @param[in] topology           Mesh topology enumeration value
-!> @param[in] mesh_collection    Optional: a collection of meshes, which contain
-!!                               metadata used to determine the rotation matrix
-!!                               and stretching factors.
-!> @param[in] north_pole_arg     Optional: target north pole, used to generate
-!!                               the rotation matrix. This is incompatible with
-!!                               the mesh_collection argument, and ideally
-!!                               should only be used for unit-testing.
-!> @param[in] equator_lat_arg    Optional: Latitude of the equator of the mesh,
+!> @param[in] north_pole_arg     Target north pole [lon,lat], used to generate
+!!                               the rotation matrix.
+!> @param[in] null_island_arg    Null island [lon,lat]
+!> @param[in] equator_lat_arg    Latitude of the equator of the mesh,
 !!                               allowing a stretching to be described.
-!!                               This is incompatible with the mesh_collection
-!!                               argument, and ideally should only be used for
-!!                               unit-testing.
 !------------------------------------------------------------------------------
 subroutine init_chi_transforms( mesh_north_pole,  &
                                 mesh_null_island, &
@@ -122,14 +113,8 @@ subroutine init_chi_transforms( mesh_north_pole,  &
 
   ! Determine degrees of stretching / rotation.
   to_stretch = abs(equator_latitude) > EPS
-
-print*, 'North Pole ', abs(north_pole(2))
-print*, 'Null island(1) ', abs(null_island(1))
-print*, 'Null island(2) ', abs(null_island(2))
-
   to_rotate = ( abs(north_pole(2) - PI/2.0_r_def) > EPS                        &
                 .or. abs(null_island(1)) > EPS .or. abs(null_island(2)) > EPS )
-print*, 'To rotate?', to_rotate
 
   ! Compute Schmidt stretch factor ---------------------------------------------
   stretch_factor = sqrt( (1.0_r_def - sin(equator_latitude))                &

--- a/components/science/source/kernel/geometry/sci_chi_transform_mod.F90
+++ b/components/science/source/kernel/geometry/sci_chi_transform_mod.F90
@@ -43,9 +43,10 @@ implicit none
 private
 
 ! ---------------------------------------------------------------------------- !
-! Private matrices or values that need computing once
+! Private matrices or values
 ! ---------------------------------------------------------------------------- !
-
+! Set values to reflect, unrotated, unstretched [lon,lat]
+! spherical mesh surface
 real(kind=r_def)    :: chi2xyz_rot_mat(3,3) = 0.0_r_def
 real(kind=r_def)    :: xyz2chi_rot_mat(3,3) = 0.0_r_def
 real(kind=r_def)    :: stretch_factor = 1.0_r_def
@@ -77,13 +78,15 @@ public :: get_to_stretch
 contains
 
 !------------------------------------------------------------------------------
-!> @brief  Initialise the coordinate transform information
-!!
-!> @param[in] north_pole_arg     Target north pole [lon,lat], used to generate
-!!                               the rotation matrix.
-!> @param[in] null_island_arg    Null island [lon,lat]
-!> @param[in] equator_lat_arg    Latitude of the equator of the mesh,
-!!                               allowing a stretching to be described.
+!> @brief  Initialise the coordinate transform information.
+!! @description  This routine should only be called for meshes with spherical
+!!               geometries. All arguments given as [longitude, latitude] on an
+!!               unrotated frame of reference. Stretching to the
+!!               mesh_equator_latitude is via Schmit transform.
+!> @param[in] mesh_north_pole        Target north pole location [lon,lat], used to
+!>                                   generate the rotation matrix.
+!> @param[in] mesh_null_island       Target Null island location [lon,lat]
+!> @param[in] mesh_equator_latitude  Target equator latitude [lat].
 !------------------------------------------------------------------------------
 subroutine init_chi_transforms( mesh_north_pole,  &
                                 mesh_null_island, &
@@ -113,11 +116,12 @@ subroutine init_chi_transforms( mesh_north_pole,  &
 
   ! Determine degrees of stretching / rotation.
   to_stretch = abs(equator_latitude) > EPS
-  to_rotate = ( abs(north_pole(2) - PI/2.0_r_def) > EPS                        &
-                .or. abs(null_island(1)) > EPS .or. abs(null_island(2)) > EPS )
+  to_rotate = ( abs(north_pole(2) - PI/2.0_r_def) > EPS .or. &
+                abs(null_island(1)) > EPS .or.               &
+                abs(null_island(2)) > EPS )
 
   ! Compute Schmidt stretch factor ---------------------------------------------
-  stretch_factor = sqrt( (1.0_r_def - sin(equator_latitude))                &
+  stretch_factor = sqrt( (1.0_r_def - sin(equator_latitude)) &
                          / (1.0_r_def + sin(equator_latitude)) )
 
   ! Compute rotation matrix ----------------------------------------------------
@@ -148,6 +152,9 @@ end subroutine init_chi_transforms
 subroutine final_chi_transforms()
 
   implicit none
+
+  ! Reset values to reflect, unrotated, unstretched [lon,lat]
+  ! spherical mesh surface
 
   to_stretch = .false.
   to_rotate = .false.

--- a/components/science/unit-test/kernel/fem/compute_broken_div_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_broken_div_operator_kernel_mod_test.pf
@@ -7,7 +7,7 @@
 !>
 module compute_broken_div_operator_kernel_mod_test
 
-    use constants_mod, only : i_def, r_def, imdi
+    use constants_mod, only : i_def, r_def
     use get_unit_test_m3x3_dofmap_mod, &
       only : get_w0_m3x3_dofmap, &
              get_w3_m3x3_dofmap
@@ -49,7 +49,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -65,22 +64,18 @@ contains
              element_order_v=1_i_def,                           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_broken_div_operator_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_curl_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_curl_operator_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_curl_operator_kernel_mod_test
 
-    use constants_mod,                       only : i_def, r_def, imdi
+    use constants_mod,                       only : i_def, r_def
     use get_unit_test_m3x3_dofmap_mod,       only : get_w0_m3x3_dofmap, &
                                                     get_w3_m3x3_dofmap
     use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
@@ -68,22 +68,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_curl_operator_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_derham_matrices_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_derham_matrices_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_derham_matrices_kernel_mod_test
 
-  use constants_mod, only: i_def, r_def, imdi
+  use constants_mod, only: i_def, r_def
   use funit
 
   implicit none
@@ -33,7 +33,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -49,22 +48,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_derham_matrices_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_div_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_div_operator_kernel_mod_test.pf
@@ -50,7 +50,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -66,22 +65,18 @@ contains
              element_order_v=1_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_div_operator_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_div_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_div_operator_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_div_operator_kernel_mod_test
 
-    use constants_mod, only : i_def, r_def, imdi
+    use constants_mod, only : i_def, r_def
     use get_unit_test_m3x3_dofmap_mod, &
       only : get_w0_m3x3_dofmap, &
              get_w3_m3x3_dofmap

--- a/components/science/unit-test/kernel/fem/compute_grad_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_grad_operator_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_grad_operator_kernel_mod_test
 
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size,  &
                                                   get_w1_m3x3_q3x3x3_size,  &
                                                   get_w3_m3x3_q3x3x3_size

--- a/components/science/unit-test/kernel/fem/compute_grad_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_grad_operator_kernel_mod_test.pf
@@ -44,7 +44,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -60,22 +59,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_grad_operator_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w1_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w1_mod_test.pf
@@ -46,7 +46,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -62,22 +61,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_mass_matrix_w1_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w1_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w1_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_mass_matrix_kernel_w1_mod_test
 
-    use constants_mod, only : i_def, r_def, imdi
+    use constants_mod, only : i_def, r_def
     use get_unit_test_m3x3_dofmap_mod, &
       only : get_w0_m3x3_dofmap, get_w3_m3x3_dofmap
     use get_unit_test_m3x3_q3x3x3_sizes_mod, &

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w2_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w2_mod_test.pf
@@ -46,7 +46,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -62,22 +61,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
     use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
 
     implicit none
 
     class(compute_mass_matrix_w2_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w2_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w2_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_mass_matrix_kernel_w2_mod_test
 
-  use constants_mod, only : i_def, r_def, imdi
+  use constants_mod, only : i_def, r_def
   use get_unit_test_m3x3_dofmap_mod, &
     only : get_w0_m3x3_dofmap, get_w3_m3x3_dofmap
   use get_unit_test_m3x3_q3x3x3_sizes_mod, &

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w3_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w3_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_mass_matrix_kernel_w3_mod_test
 
-  use constants_mod,                       only : i_def, r_def, r_single, r_double, imdi
+  use constants_mod,                       only : i_def, r_def, r_single, r_double
 
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size,  &
                                                   get_w3_m3x3_q3x3x3_size

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w3_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_w3_mod_test.pf
@@ -46,7 +46,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -62,22 +61,18 @@ contains
              element_order_v        = 0_i_def,                    &
              rehabilitate           = .true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_mass_matrix_w3_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_wtheta_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_wtheta_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module compute_mass_matrix_kernel_wtheta_mod_test
 
-  use constants_mod,        only : i_def, r_def, r_single, r_double, l_def, imdi
+  use constants_mod,        only : i_def, r_def, r_single, r_double, l_def
 
   use get_unit_test_m3x3_q3x3x3_sizes_mod,                      &
                             only : get_w0_m3x3_q3x3x3_size,     &

--- a/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_wtheta_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/compute_mass_matrix_kernel_wtheta_mod_test.pf
@@ -52,7 +52,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -68,22 +67,18 @@ contains
              element_order_v        = 0_i_def,                    &
              rehabilitate           = .true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(compute_mass_matrix_wtheta_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/gp_rhs_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/gp_rhs_kernel_mod_test.pf
@@ -45,7 +45,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -67,8 +66,6 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
     qr = quadrature_xyoz_type(3, quadrature_rule)
 
     qr_proxy = qr%get_quadrature_proxy()
@@ -85,7 +82,6 @@ contains
   subroutine tearDown( this )
 
     use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
 
     implicit none
 
@@ -94,7 +90,6 @@ contains
     deallocate( this%basis, this%basis_f, this%diff_basis )
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/gp_rhs_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/gp_rhs_kernel_mod_test.pf
@@ -7,7 +7,7 @@
 !-------------------------------------------------------------------------------
 module gp_rhs_kernel_mod_test
 
-  use constants_mod,  only : i_def, r_def, imdi
+  use constants_mod,  only : i_def, r_def
   use funit
   use quadrature_xyoz_mod,               only: quadrature_xyoz_type, &
                                                quadrature_xyoz_proxy_type

--- a/components/science/unit-test/kernel/fem/gp_vector_rhs_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/gp_vector_rhs_kernel_mod_test.pf
@@ -40,7 +40,6 @@ contains
 
     use base_mesh_config_mod,      only : geometry_planar, &
                                           topology_fully_periodic
-    use sci_chi_transform_mod,     only : init_chi_transforms
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config, &
@@ -73,8 +72,6 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(geometry_planar, topology_fully_periodic)
-
     qr = quadrature_xyoz_type(3, quadrature_rule)
 
     qr_proxy = qr%get_quadrature_proxy()
@@ -91,7 +88,6 @@ contains
   subroutine tearDown( this )
 
     use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
 
     implicit none
 
@@ -100,7 +96,6 @@ contains
     deallocate( this%basis_f, this%basis, this%diff_basis )
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/fem/mg_derham_mat_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/mg_derham_mat_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module mg_derham_mat_kernel_mod_test
 
-  use constants_mod, only : i_def, r_def, imdi
+  use constants_mod, only : i_def, r_def
   use funit
 
   implicit none

--- a/components/science/unit-test/kernel/fem/mg_derham_mat_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/fem/mg_derham_mat_kernel_mod_test.pf
@@ -33,7 +33,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -49,22 +48,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(mg_derham_mat_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/geometry/calc_da_at_w2_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/calc_da_at_w2_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module calc_dA_at_w2_kernel_mod_test
 
-  use constants_mod, only : i_def, r_def, imdi
+  use constants_mod, only : i_def, r_def
 
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
                                                   get_w2_m3x3_q3x3x3_size, &
@@ -45,7 +45,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -61,22 +60,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(calc_dA_at_w2_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/geometry/calc_detj_at_w2_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/calc_detj_at_w2_kernel_mod_test.pf
@@ -46,7 +46,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -62,22 +61,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(calc_detj_at_w2_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/geometry/calc_detj_at_w2_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/calc_detj_at_w2_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module calc_detj_at_w2_kernel_mod_test
 
-    use constants_mod, only : i_def, r_def, imdi
+    use constants_mod, only : i_def, r_def
     use funit
 
     use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &

--- a/components/science/unit-test/kernel/geometry/calc_detj_at_w3_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/calc_detj_at_w3_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module calc_detj_at_w3_kernel_mod_test
 
-    use constants_mod, only: imdi, i_def, r_def, r_single, r_double
+    use constants_mod, only: i_def, r_def, r_single, r_double
     use funit
 
     use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &

--- a/components/science/unit-test/kernel/geometry/calc_detj_at_w3_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/calc_detj_at_w3_kernel_mod_test.pf
@@ -45,7 +45,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -61,22 +60,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(calc_detj_at_w3_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/geometry/calc_directional_detj_at_w2_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/calc_directional_detj_at_w2_kernel_mod_test.pf
@@ -8,7 +8,7 @@
 !>
 module calc_directional_detj_at_w2_kernel_mod_test
 
-    use constants_mod, only : i_def, r_def, imdi
+    use constants_mod, only : i_def, r_def
     use funit
 
     use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
@@ -44,7 +44,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -60,22 +59,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(calc_directional_detj_at_w2_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/geometry/chi_transform_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/chi_transform_mod_test.pf
@@ -240,7 +240,7 @@ contains
 
     class(chi_transform_mod_test_type), intent(inout) :: this
 
-    real(r_def) :: north_pole(2), equatorial_latitude
+    real(r_def) :: north_pole(2), equator_latitude
 
     select case ( this%source_coord_system )
     case ( XYZ )
@@ -260,21 +260,20 @@ contains
     this%scaled_radius = planet_radius*scaling
 
     if ( this%source_coord_system == LLH_rot ) then
-      north_pole(1) = PI/2.0_r_def
-      north_pole(2) = 0.0_r_def
-      call init_chi_transforms(this%geometry, this%topology, &
-                               north_pole_arg=north_pole)
-    else if ( this%source_coord_system == ABH_stretch_rot ) then
-      north_pole(1) = -PI/2.0_r_def
-      north_pole(2) = 0.0_r_def
-      equatorial_latitude = PI/6.0_r_def
-      call init_chi_transforms(this%geometry, this%topology, &
-                               north_pole_arg=north_pole, &
-                               equator_lat_arg=equatorial_latitude)
-    else
-      ! Non-rotated or stretched case
-      call init_chi_transforms(this%geometry, this%topology)
+      north_pole = [PI/2.0_r_def, 0.0_r_def]
+      equator_latitude = 0.0_r_def
 
+      call init_chi_transforms( north_pole,             &
+                                [0.0_r_def, 0.0_r_def], &
+                                equator_latitude )
+
+    else if ( this%source_coord_system == ABH_stretch_rot ) then
+      north_pole = [-PI/2.0_r_def, 0.0_r_def]
+      equator_latitude = PI/6.0_r_def
+
+      call init_chi_transforms( north_pole,            &
+                               [0.0_r_def, 0.0_r_def], &
+                               equator_latitude )
     end if
 
   end subroutine setUp
@@ -282,8 +281,8 @@ contains
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use sci_chi_transform_mod, only: final_chi_transforms
     use config_loader_mod,     only: final_configuration
+    use sci_chi_transform_mod, only: final_chi_transforms
 
     implicit none
 

--- a/components/science/unit-test/kernel/geometry/compute_latlon_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/compute_latlon_kernel_mod_test.pf
@@ -21,34 +21,10 @@ module compute_latlon_kernel_mod_test
   implicit none
 
   private
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-  use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(imdi, imdi)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @Test

--- a/components/science/unit-test/kernel/geometry/coordinate_jacobian_alphabetaz_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/coordinate_jacobian_alphabetaz_mod_test.pf
@@ -16,35 +16,11 @@ module coordinate_jacobian_alphabetaz_mod_test
 
   implicit none
 
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
   real(r_def), parameter :: radius = 1000_r_def
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_spherical, topology_fully_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @test

--- a/components/science/unit-test/kernel/geometry/coordinate_jacobian_lonlatz_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/coordinate_jacobian_lonlatz_mod_test.pf
@@ -16,38 +16,17 @@ module coordinate_jacobian_lonlatz_mod_test
 
   implicit none
 
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
   real(r_def), parameter :: radius = 270_r_def
 
 contains
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    implicit none
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @test
   subroutine test_all()
 
     use, intrinsic :: iso_fortran_env, only: real64
-    use sci_chi_transform_mod,   only : init_chi_transforms
     use sci_coordinate_jacobian_mod,                                           &
                                  only : coordinate_jacobian,                   &
                                         coordinate_jacobian_inverse,           &
@@ -131,8 +110,6 @@ contains
     end do
 
     basis(:,:,:,:) = 0.125_r_def
-
-    call init_chi_transforms(geometry, topology)
 
     call coordinate_jacobian(coord_system, geometry, topology, scaled_radius, &
                              ndf, ngp, ngp, longitude, latitude, height,      &

--- a/components/science/unit-test/kernel/geometry/coordinate_jacobian_xyz_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/coordinate_jacobian_xyz_mod_test.pf
@@ -18,40 +18,10 @@ module coordinate_jacobian_xyz_mod_test
   type, extends(TestCase) :: jacobian_xyz_test_type
     private
   contains
-    procedure setUp
-    procedure tearDown
     procedure test_all
   end type jacobian_xyz_test_type
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  subroutine setUp( this )
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    class(jacobian_xyz_test_type), intent(inout) :: this
-
-    call init_chi_transforms(imdi, imdi)
-
-  end subroutine setUp
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  subroutine tearDown( this )
-
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    class(jacobian_xyz_test_type), intent(inout) :: this
-
-    call final_configuration()
-    call final_chi_transforms()
-
-  end subroutine tearDown
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @Test

--- a/components/science/unit-test/kernel/geometry/coordinate_jacobian_xyz_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/coordinate_jacobian_xyz_mod_test.pf
@@ -8,7 +8,7 @@
 module coordinate_jacobian_xyz_mod_test
 
   use funit
-  use constants_mod, only : r_def, i_def, imdi
+  use constants_mod, only : r_def, i_def
 
   implicit none
 

--- a/components/science/unit-test/kernel/geometry/native_jacobian_alphabetaz_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/native_jacobian_alphabetaz_mod_test.pf
@@ -15,35 +15,11 @@ module native_jacobian_alphabetaz_mod_test
 
   implicit none
 
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
   real(r_def), parameter :: radius = 1000_r_def
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod,     only : init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_spherical, topology_fully_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @test

--- a/components/science/unit-test/kernel/geometry/native_jacobian_lonlatz_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/native_jacobian_lonlatz_mod_test.pf
@@ -16,35 +16,11 @@ module native_jacobian_lonlatz_mod_test
 
   implicit none
 
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
   real(r_def), parameter :: radius = 270_r_def
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_spherical, topology_non_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @test

--- a/components/science/unit-test/kernel/geometry/native_jacobian_xyz_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/native_jacobian_xyz_mod_test.pf
@@ -18,40 +18,10 @@ module native_jacobian_xyz_mod_test
   type, extends(TestCase) :: jacobian_xyz_test_type
     private
   contains
-    procedure setUp
-    procedure tearDown
     procedure test_all
   end type jacobian_xyz_test_type
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  subroutine setUp( this )
-
-    use sci_chi_transform_mod, only : init_chi_transforms
-
-    implicit none
-
-    class(jacobian_xyz_test_type), intent(inout) :: this
-
-    call init_chi_transforms(imdi, imdi)
-
-  end subroutine setUp
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  subroutine tearDown( this )
-
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    class(jacobian_xyz_test_type), intent(inout) :: this
-
-    call final_configuration()
-    call final_chi_transforms()
-
-  end subroutine tearDown
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @Test

--- a/components/science/unit-test/kernel/geometry/nodal_xyz_coordinates_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/nodal_xyz_coordinates_kernel_mod_test.pf
@@ -27,34 +27,10 @@ module nodal_xyz_coordinates_kernel_mod_test
   implicit none
 
   private
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(imdi, imdi)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @Test

--- a/components/science/unit-test/kernel/geometry/scale_by_detj_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/scale_by_detj_kernel_mod_test.pf
@@ -35,7 +35,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -51,22 +50,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
     use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
 
     implicit none
 
     class(scale_by_detj_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/geometry/scale_by_detj_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/geometry/scale_by_detj_kernel_mod_test.pf
@@ -7,7 +7,7 @@
 !> Test the scale by detJ kernel
 module scale_by_detj_kernel_mod_test
 
-  use constants_mod, only : i_def, r_def, imdi
+  use constants_mod, only : i_def, r_def
   use funit
   use get_unit_test_wthetanodal_basis_mod, only : get_w0_wthetanodal_basis, &
                                                   get_w0_wthetanodal_diff_basis

--- a/components/science/unit-test/kernel/inter_function_space/compute_map_u_operators_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/compute_map_u_operators_kernel_mod_test.pf
@@ -19,33 +19,9 @@ module compute_map_u_operators_kernel_mod_test
   implicit none
 
   private
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_spherical,topology_non_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @test

--- a/components/science/unit-test/kernel/inter_function_space/compute_sample_u_ops_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/compute_sample_u_ops_kernel_mod_test.pf
@@ -20,33 +20,9 @@ module compute_sample_u_ops_kernel_mod_test
   implicit none
 
   private
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_spherical, topology_non_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @test

--- a/components/science/unit-test/kernel/inter_function_space/convert_hcurl_field_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/convert_hcurl_field_kernel_mod_test.pf
@@ -6,7 +6,7 @@
 
 module convert_hcurl_field_kernel_mod_test
 
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
                                                   get_w1_m3x3_q3x3x3_size, &
                                                   get_w3_m3x3_q3x3x3_size

--- a/components/science/unit-test/kernel/inter_function_space/convert_hcurl_field_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/convert_hcurl_field_kernel_mod_test.pf
@@ -41,7 +41,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -57,22 +56,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(convert_hcurl_field_kernel_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_function_space/convert_hdiv_field_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/convert_hdiv_field_kernel_mod_test.pf
@@ -6,7 +6,7 @@
 
 module convert_hdiv_field_kernel_mod_test
 
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
                                                   get_w2_m3x3_q3x3x3_size, &
                                                   get_w3_m3x3_q3x3x3_size

--- a/components/science/unit-test/kernel/inter_function_space/convert_hdiv_field_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/convert_hdiv_field_kernel_mod_test.pf
@@ -41,7 +41,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -57,22 +56,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(convert_hdiv_field_kernel_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_function_space/convert_hdiv_native_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/convert_hdiv_native_kernel_mod_test.pf
@@ -41,7 +41,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -57,22 +56,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(convert_hdiv_native_kernel_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_function_space/convert_hdiv_native_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/convert_hdiv_native_kernel_mod_test.pf
@@ -6,7 +6,7 @@
 
 module convert_hdiv_native_kernel_mod_test
 
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
                                                   get_w2_m3x3_q3x3x3_size, &
                                                   get_w3_m3x3_q3x3x3_size

--- a/components/science/unit-test/kernel/inter_function_space/convert_phys_to_hdiv_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/convert_phys_to_hdiv_kernel_mod_test.pf
@@ -18,33 +18,9 @@ module convert_phys_to_hdiv_kernel_mod_test
   implicit none
 
   private
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_planar, topology_fully_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @Test

--- a/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_field_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_field_kernel_mod_test.pf
@@ -45,7 +45,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -61,22 +60,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(dg_convert_hdiv_field_kernel_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_field_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_field_kernel_mod_test.pf
@@ -5,7 +5,7 @@
 !-----------------------------------------------------------------------------
 module dg_convert_hdiv_field_kernel_mod_test
 
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
                                                   get_w2_m3x3_q3x3x3_size, &
                                                   get_w3_m3x3_q3x3x3_size, &

--- a/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_native_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_native_kernel_mod_test.pf
@@ -4,7 +4,7 @@
 ! under which the code may be used.
 !-----------------------------------------------------------------------------
 module dg_convert_hdiv_native_kernel_mod_test
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
                                                   get_w2_m3x3_q3x3x3_size, &
                                                   get_w3_m3x3_q3x3x3_size

--- a/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_native_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/dg_convert_hdiv_native_kernel_mod_test.pf
@@ -42,7 +42,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -58,22 +57,18 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   subroutine tearDown( this )
 
     use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
 
     implicit none
 
     class(dg_convert_hdiv_native_kernel_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_function_space/project_w3_to_w2b_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/project_w3_to_w2b_operator_kernel_mod_test.pf
@@ -32,7 +32,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -48,22 +47,18 @@ contains
              rehabilitate=.true.,               &
              coord_system=coord_system_xyz )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(project_w3_to_w2b_operator_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_function_space/project_w3_to_w2b_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/project_w3_to_w2b_operator_kernel_mod_test.pf
@@ -7,7 +7,7 @@
 !> Test the kernel for computing the operator to projec from W3 to W2b
 module project_w3_to_w2b_operator_kernel_mod_test
 
-  use constants_mod, only : i_def, r_def, imdi
+  use constants_mod, only : i_def, r_def
   use funit
 
   implicit none

--- a/components/science/unit-test/kernel/inter_function_space/project_ws_to_w1_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/project_ws_to_w1_operator_kernel_mod_test.pf
@@ -30,33 +30,9 @@ module project_ws_to_w1_operator_kernel_mod_test
   implicit none
 
   private
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_planar,topology_fully_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @Test

--- a/components/science/unit-test/kernel/inter_function_space/project_ws_to_w2_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/project_ws_to_w2_operator_kernel_mod_test.pf
@@ -32,7 +32,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
 
     implicit none
 
@@ -48,22 +47,18 @@ contains
              rehabilitate=.true.,               &
              coord_system=coord_system_xyz )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(project_ws_to_w2_operator_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_function_space/project_ws_to_w2_operator_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/project_ws_to_w2_operator_kernel_mod_test.pf
@@ -7,7 +7,7 @@
 !> Test the projection from a scalar space to W2
 module project_ws_to_w2_operator_kernel_mod_test
 
-  use constants_mod, only : i_def, r_def, imdi
+  use constants_mod, only : i_def, r_def
   use funit
 
   implicit none

--- a/components/science/unit-test/kernel/inter_function_space/w3_to_w2_displacement_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_function_space/w3_to_w2_displacement_kernel_mod_test.pf
@@ -20,33 +20,9 @@ module w3_to_w2_displacement_kernel_mod_test
   implicit none
 
   private
-  public :: set_up, tear_down, test_all
+  public :: test_all
 
 contains
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @before
-  subroutine set_up()
-
-    use sci_chi_transform_mod, only: init_chi_transforms
-
-    implicit none
-
-    call init_chi_transforms(geometry_spherical, topology_fully_periodic)
-
-  end subroutine set_up
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  @after
-  subroutine tear_down()
-
-    use sci_chi_transform_mod, only: final_chi_transforms
-
-    implicit none
-
-    call final_chi_transforms()
-
-  end subroutine tear_down
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   @test

--- a/components/science/unit-test/kernel/inter_mesh/consist_w3_to_sh_w3_op_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_mesh/consist_w3_to_sh_w3_op_kernel_mod_test.pf
@@ -33,8 +33,6 @@ contains
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
-    use sci_chi_transform_mod,     only : init_chi_transforms
-
 
     implicit none
 
@@ -50,22 +48,17 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
-
 
     class(consist_w3_to_sh_w3_op_kernel_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 

--- a/components/science/unit-test/kernel/inter_mesh/consist_w3_to_sh_w3_op_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_mesh/consist_w3_to_sh_w3_op_kernel_mod_test.pf
@@ -6,7 +6,7 @@
 !> Test the consist_w3_to_sh_w3_op kernel
 !>
 module consist_w3_to_sh_w3_op_kernel_mod_test
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w3_m3x3_q3x3x3_size
   use get_unit_test_m3x3_dofmap_mod,       only : get_w3_m3x3_dofmap
   use funit

--- a/components/science/unit-test/kernel/inter_mesh/proj_mr_to_sh_rho_rhs_op_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_mesh/proj_mr_to_sh_rho_rhs_op_kernel_mod_test.pf
@@ -7,7 +7,7 @@
 !>
 module proj_mr_to_sh_rho_rhs_op_kernel_mod_test
 
-  use constants_mod,                       only : i_def, r_def, imdi
+  use constants_mod,                       only : i_def, r_def
   use get_unit_test_m3x3_q3x3x3_sizes_mod, only : get_w0_m3x3_q3x3x3_size, &
                                                   get_w3_m3x3_q3x3x3_size, &
                                                   get_wtheta_m3x3_q3x3x3_size

--- a/components/science/unit-test/kernel/inter_mesh/proj_mr_to_sh_rho_rhs_op_kernel_mod_test.pf
+++ b/components/science/unit-test/kernel/inter_mesh/proj_mr_to_sh_rho_rhs_op_kernel_mod_test.pf
@@ -42,7 +42,6 @@ contains
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine setUp( this )
 
-    use sci_chi_transform_mod,     only : init_chi_transforms
     use finite_element_config_mod, only : cellshape_quadrilateral, &
                                           coord_system_xyz, coord_space_wchi
     use feign_config_mod,          only : feign_finite_element_config
@@ -61,21 +60,17 @@ contains
              element_order_v=0_i_def,           &
              rehabilitate=.true. )
 
-    call init_chi_transforms(imdi, imdi)
-
   end subroutine setUp
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine tearDown( this )
 
-    use config_loader_mod,     only: final_configuration
-    use sci_chi_transform_mod, only: final_chi_transforms
+    use config_loader_mod, only: final_configuration
 
     implicit none
 
     class(proj_mr_to_sh_rho_rhs_op_test_type), intent(inout) :: this
 
     call final_configuration()
-    call final_chi_transforms()
 
   end subroutine tearDown
 


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @tommbendall
Code Reviewer: @mike-hobson 

While generating the _**chi**_ fields from meshes, the routine **_init_chi_transform_** is called from **_init_fem_**. The implementation of this is rather complicated and has in the past resulted in changes to test-suite KGOs if altered. This PR refactors/simplifies the implementation.

### Issues with the existing implementation.
The initial chi transform as it stands:
  * Passes in a mesh collection by argument (when it is available in module scope), only to extract the 1st mesh (which is only dependent on load order) to obtain the North Pole, Null Island, Equator latitude from the mesh. It doesn't allow for the case where there may be different meshes in the collection such as with the `lfric2lfric` application.
  * The variables in the module `init_chi_transform_mod` are uninitialized and  require that `init_chi_transform` is called in order to prevent random data. The transform is only for certain meshes (spherical geometry), however, omitting the call to `init_chi_transform` when not required still resulted in some KGO changes in the test-suite tasks. 
  * While the initialization is required only once, calls are made from `init_fem` for each mesh in the mesh_collection. 

### PR changes
* Simplify the API, only the key reference points are sent to the routine, **_north_pole_**, **_null_island_**, **_equator_latitiude_**. The determination of what those values are should be made by the application, though for the purposes of this PR, that determination is still applied in `init_fem`.
*  Initialise (on declaration) and finalise the settings in `init_chi_transform_mod` so that they are for the default case, _i.e._ unrotated, unstretched mesh, to prevent random data.
* Only require the **init_chi_transform** to be called once for spherical geometry meshes. Even then its only necessary if the mesh has been rotated or stretched. This removes the bulk of required calls to **_init_chi_transform_** in the unit-tests routines.

### Out-of-Scope issue
The current change refactors and tidies the existing code. Though there is still the issue of assuming that all spherical meshes in an application will use the pole/stretching criteria held in the module _**sci_chi_transforms_mod**_. Specifically in the general case with lfric2lfric where source/destination meshes could potentially have different pole location/stretching criteria.

### Linked PRs
- linked MetOffice/lfric_apps#749

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] I have tested this change locally, using the LFRic Core rose-stem suite
- [x] If required (e.g. API changes) I have also run the LFRic Apps test suite using this branch
- [ ] If any tests fail (rose-stem or CI) the reason is understood and acceptable (e.g. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (e.g. system tests, unit tests, etc.)
- [ ] Any new tests have been assigned an appropriate amount of compute resource and have been allocated to an appropriate testing group (i.e. the developer tests are for jobs which use a small amount of compute resource and complete in a matter of minutes)

### trac.log

# Test Suite Results - lfric_core - RefactorChiTrans/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [RefactorChiTrans/run1](https://cylchub/services/cylc-review/cycles/ricky.wong/?suite=RefactorChiTrans%2Frun1) |
| Suite User | ricky.wong |
| Workflow Start | 2026-09-03T07:04:11 |
| Groups Run | developer |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| lfric_core | [mo-rickywong/lfric_core@RefactorChiTrans](https://github.com/mo-rickywong/lfric_core/tree/RefactorChiTrans) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@cab3315](https://github.com/MetOffice/SimSys_Scripts/tree/cab3315) | True |

## Task Information
:white_check_mark: succeeded tasks - 433

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and confirmed that it builds correctly

## PSyclone Approval

- [ ] If you have edited any PSyclone-related code (e.g. PSyKAl-lite, Kernel interface, optimisation scripts, LFRic data structure code) then please contact the [HPC Optimisation Team](mailto:ML-NC-Prediction-SMIT-HPCOptimisation@metoffice.gov.uk)

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [x] I understand this area of code and the changes being added
- [x] The proposed changes correspond to the pull request description
- [x] Documentation is sufficient (do documentation papers need updating)
- [x] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
